### PR TITLE
25 Added files field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "main": "dist/ui-kit.js",
   "module": "dist/ui-kit.mjs",
   "types": "dist/ui-kit.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
We have non-standard build directory at the very moment, so npm includes all the files in repository in release, but we need only ```dist```, ```package.json``` and some extra files like ```README.md```. This diff adds ```fields``` property in ```package.json```, which allows to include only ```dist``` into final npm package release.