### PR TITLE
25 Add publish workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,27 +1,20 @@
 name: Build
-
 on:
-  # Triggers the workflow on every pull-request
   pull_request:
-  # Allows to trigger workflow manually
   workflow_dispatch:
-
 jobs:
   build:
     name: Build
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-
     - name: Setup Nodejs
       uses: actions/setup-node@v3
       with:
         node-version: 18.x
-
     - name: Install dependencies
       run: npm ci
-
     - name: Build
       run: |
         npm run build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,19 @@
+name: Publish Package
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: Release
+on:
+  push:
+    tags:
+    - 'v*'
+jobs:
+  release:
+    if: ${{ github.ref == 'refs/heads/master' }} # run only after push tags to master branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ncipollo/release-action@v1
+      with:
+        generateReleaseNotes: true

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint": "eslint 'src/**/**/*.{js,ts,tsx}'",
     "tsc": "tsc --noEmit",
     "storybook": "start-storybook -s ./src/assets -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "postversion": "git push --tags"
   },
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
This diff adds simple package release/publish workflow.
It is supposed, that developer will bump package version, when they think it is needed using ```npm version``` command.
Version should be bumped only manually, because only developer should decide when to do this.
If run in a git repo, ```npm version``` command will also create a version commit and tag by default.

After pushing new tag to master branch (or merging PR with new tag into master), which starts with ```v```, release workflow will run and create new release, automatically generating release notes.

New release will trigger publish workflow, which publishes package to npm registry.

Also, this diff adds ```postversion``` npm script with ```git push --tags``` command, in order not to forget to push tags after bumping package version. If developer will bump version without adding tags, package will not publish automatically, but still could be published manually.

**Version bump commits should not be squashed, because in other case tags would not be pushed into master.**