### PR TITLE
25 release workflow fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
     - 'v*'
+  workflow_dispatch:
 jobs:
   release:
     if: ${{ github.ref == 'refs/heads/master' }} # run only after push tags to master branch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   release:
-    if: ${{ github.ref == 'refs/heads/master' }} # run only after push tags to master branch
+    if: ${{ github.event.base_ref == 'refs/heads/master' }} # run only after push tags to master branch
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This diff allows to run `release` workflow manually and fixes condition to run. Because when push tags, `github.ref` will be something like `refs/tags/v3.14.1`, so we could not use it to detect whether it was push to master or not.