### PR TITLE
25 Remove dev dependencies from final package bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
   plugins: [
     react(),
     eslint(),
-    externalizeDeps(),
+    externalizeDeps({
+      devDeps: true
+    }),
     dts({ staticImport: true, outputDir: './dist/.temp' }),
   ],
   build: {


### PR DESCRIPTION
This diff prevents `styletron-react` from being bundled in final package build artifact.