### PR TITLE
25 Add storySort option to storybook parameters

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -19,5 +19,10 @@ export const parameters = {
   },
   docs: {
     theme
+  },
+  options: {
+    storySort: {
+      order: ['Documentation'],
+    },
   }
 };


### PR DESCRIPTION
This diff adds sorting stories in order to show `Documentation` block first.