### PR TITLE
25 remove styletron-engine-atomic from package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "baseui": ">=12.2.0",
-        "react": ">=17.0.2",
-        "react-dom": ">=17.0.2"
+        "inline-style-expand-shorthand": "^1.6.0",
+        "styletron-standard": "^3.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.1",
@@ -38,11 +37,9 @@
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-unused-imports": "^2.0.0",
-        "inline-style-expand-shorthand": "^1.6.0",
         "pre-commit": "^1.2.2",
         "prettier": "^2.8.8",
         "styletron-engine-atomic": "^1.5.0",
-        "styletron-react": "^6.1.0",
         "typescript": "4.9.5",
         "vite": "^4.3.9",
         "vite-plugin-dts": "^2.3.0",
@@ -52,7 +49,8 @@
       "peerDependencies": {
         "baseui": ">=12.2.0",
         "react": ">=17.0.2",
-        "react-dom": ">=17.0.2"
+        "react-dom": ">=17.0.2",
+        "styletron-react": ">=6.1.0 < 7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2164,12 +2162,14 @@
     "node_modules/@date-io/core": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.16.0.tgz",
-      "integrity": "sha512-DYmSzkr+jToahwWrsiRA2/pzMEtz9Bq1euJwoOuYwuwIYXnZFtHajY2E6a1VNVDc9jP8YUXK1BvnZH9mmT19Zg=="
+      "integrity": "sha512-DYmSzkr+jToahwWrsiRA2/pzMEtz9Bq1euJwoOuYwuwIYXnZFtHajY2E6a1VNVDc9jP8YUXK1BvnZH9mmT19Zg==",
+      "peer": true
     },
     "node_modules/@date-io/date-fns": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.16.0.tgz",
       "integrity": "sha512-bfm5FJjucqlrnQcXDVU5RD+nlGmL3iWgkHTq3uAZWVIuBu6dDmGa3m8a6zo2VQQpu8ambq9H22UyUpn7590joA==",
+      "peer": true,
       "dependencies": {
         "@date-io/core": "^2.16.0"
       },
@@ -10381,6 +10381,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz",
       "integrity": "sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -10389,6 +10390,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
       "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -11622,6 +11624,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
       "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
+      "peer": true,
       "dependencies": {
         "core-js": "^2.5.0"
       },
@@ -11634,7 +11637,8 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "peer": true
     },
     "node_modules/autoprefixer": {
       "version": "9.8.8",
@@ -12020,6 +12024,7 @@
       "resolved": "https://registry.npmjs.org/baseui/-/baseui-12.2.0.tgz",
       "integrity": "sha512-GDooNcxztwg71dkf69bw4Of/nM56adWFvo4VXkU5iVVhLHB0X60ngT+9J2LLOG7F9+s5LQzSXhRO62OiPhLsHA==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@date-io/date-fns": "^2.6.2",
         "@types/react-virtualized-auto-sizer": "^1.0.0",
@@ -12060,6 +12065,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
       "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -12071,6 +12077,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.2.tgz",
       "integrity": "sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -12786,6 +12793,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-6.2.0.tgz",
       "integrity": "sha512-1vYv45JaE9NmixZr4dl6ykzbFKv7imI9L7MQDs235b/a7EGbG8rrEsipeHtVvscLSUbl3RX6UP5gyOe0Y2FlHA==",
+      "peer": true,
       "dependencies": {
         "credit-card-type": "^8.0.0"
       }
@@ -13888,7 +13896,8 @@
     "node_modules/credit-card-type": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/credit-card-type/-/credit-card-type-8.3.0.tgz",
-      "integrity": "sha512-czfZUpQ7W9CDxZL4yFLb1kFtM/q2lTOY975hL2aO+DC8+GRNDVSXVCHXhVFZPxiUKmQCZbFP8vIhxx5TBQaThw=="
+      "integrity": "sha512-czfZUpQ7W9CDxZL4yFLb1kFtM/q2lTOY975hL2aO+DC8+GRNDVSXVCHXhVFZPxiUKmQCZbFP8vIhxx5TBQaThw==",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -14169,6 +14178,7 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
       "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
+      "peer": true,
       "dependencies": {
         "d3-array": "2",
         "d3-axis": "2",
@@ -14206,6 +14216,7 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "peer": true,
       "dependencies": {
         "internmap": "^1.0.0"
       }
@@ -14213,12 +14224,14 @@
     "node_modules/d3-axis": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
-      "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw=="
+      "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw==",
+      "peer": true
     },
     "node_modules/d3-brush": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
       "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 2",
         "d3-drag": "2",
@@ -14231,6 +14244,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
       "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
+      "peer": true,
       "dependencies": {
         "d3-path": "1 - 2"
       }
@@ -14238,12 +14252,14 @@
     "node_modules/d3-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "peer": true
     },
     "node_modules/d3-contour": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
       "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
+      "peer": true,
       "dependencies": {
         "d3-array": "2"
       }
@@ -14252,6 +14268,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
       "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "peer": true,
       "dependencies": {
         "delaunator": "4"
       }
@@ -14259,12 +14276,14 @@
     "node_modules/d3-dispatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
-      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "peer": true
     },
     "node_modules/d3-drag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
       "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 2",
         "d3-selection": "2"
@@ -14274,6 +14293,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
       "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "peer": true,
       "dependencies": {
         "commander": "2",
         "iconv-lite": "0.4",
@@ -14294,17 +14314,20 @@
     "node_modules/d3-dsv/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
     },
     "node_modules/d3-ease": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
-      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "peer": true
     },
     "node_modules/d3-fetch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
       "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
+      "peer": true,
       "dependencies": {
         "d3-dsv": "1 - 2"
       }
@@ -14313,6 +14336,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
       "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 2",
         "d3-quadtree": "1 - 2",
@@ -14322,12 +14346,14 @@
     "node_modules/d3-format": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
+      "peer": true
     },
     "node_modules/d3-geo": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
       "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "peer": true,
       "dependencies": {
         "d3-array": "^2.5.0"
       }
@@ -14335,12 +14361,14 @@
     "node_modules/d3-hierarchy": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
-      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==",
+      "peer": true
     },
     "node_modules/d3-interpolate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
       "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "peer": true,
       "dependencies": {
         "d3-color": "1 - 2"
       }
@@ -14348,27 +14376,32 @@
     "node_modules/d3-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
-      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==",
+      "peer": true
     },
     "node_modules/d3-polygon": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
-      "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
+      "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==",
+      "peer": true
     },
     "node_modules/d3-quadtree": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
-      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw==",
+      "peer": true
     },
     "node_modules/d3-random": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
-      "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
+      "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==",
+      "peer": true
     },
     "node_modules/d3-scale": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
       "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "peer": true,
       "dependencies": {
         "d3-array": "^2.3.0",
         "d3-format": "1 - 2",
@@ -14381,6 +14414,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
       "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
+      "peer": true,
       "dependencies": {
         "d3-color": "1 - 2",
         "d3-interpolate": "1 - 2"
@@ -14389,12 +14423,14 @@
     "node_modules/d3-selection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "peer": true
     },
     "node_modules/d3-shape": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
       "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "peer": true,
       "dependencies": {
         "d3-path": "1 - 2"
       }
@@ -14403,6 +14439,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "peer": true,
       "dependencies": {
         "d3-array": "2"
       }
@@ -14411,6 +14448,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
       "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "peer": true,
       "dependencies": {
         "d3-time": "1 - 2"
       }
@@ -14418,12 +14456,14 @@
     "node_modules/d3-timer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
-      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "peer": true
     },
     "node_modules/d3-transition": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
       "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "peer": true,
       "dependencies": {
         "d3-color": "1 - 2",
         "d3-dispatch": "1 - 2",
@@ -14439,6 +14479,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
       "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 2",
         "d3-drag": "2",
@@ -14451,6 +14492,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -14466,6 +14508,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
       "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+      "peer": true,
       "peerDependencies": {
         "date-fns": ">=2.0.0"
       }
@@ -14474,6 +14517,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
       "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -14626,7 +14670,8 @@
     "node_modules/delaunator": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
-      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
+      "peer": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -14688,7 +14733,8 @@
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "peer": true
     },
     "node_modules/detect-package-manager": {
       "version": "2.0.1",
@@ -14776,6 +14822,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -14785,6 +14832,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
       "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -16248,6 +16296,7 @@
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
       "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -16518,6 +16567,7 @@
       "version": "0.11.6",
       "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
       "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -17897,8 +17947,7 @@
     "node_modules/inline-style-expand-shorthand": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/inline-style-expand-shorthand/-/inline-style-expand-shorthand-1.6.0.tgz",
-      "integrity": "sha512-REormb3TCk/CIeL5/Q1rdHYM9tW8YKGKzbvgAH4IXrDsJmq9BnV69yhIGGMzV2IRkR/J6MuLNhY7UfoIJjunog==",
-      "dev": true
+      "integrity": "sha512-REormb3TCk/CIeL5/Q1rdHYM9tW8YKGKzbvgAH4IXrDsJmq9BnV69yhIGGMzV2IRkR/J6MuLNhY7UfoIJjunog=="
     },
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
@@ -17931,7 +17980,8 @@
     "node_modules/internmap": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "peer": true
     },
     "node_modules/interpret": {
       "version": "2.2.0",
@@ -17946,6 +17996,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -19102,7 +19153,8 @@
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "peer": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -19564,7 +19616,8 @@
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "peer": true
     },
     "node_modules/memoizerific": {
       "version": "1.11.3",
@@ -20003,7 +20056,8 @@
     "node_modules/mockdate": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
-      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ=="
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "peer": true
     },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
@@ -21224,6 +21278,7 @@
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
       "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -21634,6 +21689,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
       "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "peer": true,
       "dependencies": {
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
@@ -21870,6 +21926,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -21882,6 +21939,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
       "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13"
       },
@@ -21893,6 +21951,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
       "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -21955,6 +22014,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -21968,6 +22028,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
       "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
+      "peer": true,
       "dependencies": {
         "attr-accept": "^1.1.3",
         "file-selector": "^0.1.8",
@@ -22015,6 +22076,7 @@
       "version": "2.9.4",
       "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
       "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.11.6",
@@ -22037,6 +22099,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
       "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
         "warning": "^4.0.2"
@@ -22068,7 +22131,8 @@
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "peer": true
     },
     "node_modules/react-merge-refs": {
       "version": "1.1.0",
@@ -22084,6 +22148,7 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/react-movable/-/react-movable-2.5.4.tgz",
       "integrity": "sha512-F+Ml4Il9S7uyY2Nr/UzwnXxWewwsHdQkmwgzAjk+Dsz73sy2yCJk7GkQkdqmh8W6XXTlviepz1VA0eHUWh9MZQ==",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.3.0-0 || ^17.0.0-0",
         "react-dom": "^16.3.0-0 || ^17.0.0-0"
@@ -22093,6 +22158,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/react-multi-ref/-/react-multi-ref-1.0.1.tgz",
       "integrity": "sha512-zgQKmduv95vtXIkze6583pRW7Y+mNj7R0bYgxIRWOrsEfxBQaK+MZ6yjTiZ/qcFV4bYGM74nE9isb+YRBNIw2g==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.1.2"
       }
@@ -22101,6 +22167,7 @@
       "version": "1.8.14",
       "resolved": "https://registry.npmjs.org/react-range/-/react-range-1.8.14.tgz",
       "integrity": "sha512-v2nyD5106rHf9dwHzq+WRlhCes83h1wJRHIMFjbZsYYsO6LF4mG/mR3cH7Cf+dkeHq65DItuqIbLn/3jjYjsHg==",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0",
         "react-dom": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
@@ -22119,6 +22186,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.3.3.tgz",
       "integrity": "sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -22139,6 +22207,7 @@
       "version": "9.22.5",
       "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.5.tgz",
       "integrity": "sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "clsx": "^1.0.4",
@@ -22156,6 +22225,7 @@
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
       "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
+      "peer": true,
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
@@ -22165,6 +22235,7 @@
       "version": "1.8.9",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.9.tgz",
       "integrity": "sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": ">=3.1.1 <6"
@@ -22725,7 +22796,8 @@
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -22870,7 +22942,8 @@
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "peer": true
     },
     "node_modules/safe-array-concat": {
       "version": "1.0.0",
@@ -23228,6 +23301,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -24350,6 +24424,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/styletron-react/-/styletron-react-6.1.0.tgz",
       "integrity": "sha512-PHT5KUaTJKmZdA3W6lV7M+/mgn0+JzuFRiteVZHw3ApLlXwkAZMMy2NwyBwRfx/Q5EZyJvQtoOCif6hY0nVWaA==",
+      "peer": true,
       "dependencies": {
         "prop-types": "^15.6.0",
         "styletron-standard": "^3.1.0"
@@ -25408,6 +25483,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
       "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -25428,6 +25504,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
       "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "peer": true,
       "dependencies": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
@@ -25805,6 +25882,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -28089,12 +28167,14 @@
     "@date-io/core": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.16.0.tgz",
-      "integrity": "sha512-DYmSzkr+jToahwWrsiRA2/pzMEtz9Bq1euJwoOuYwuwIYXnZFtHajY2E6a1VNVDc9jP8YUXK1BvnZH9mmT19Zg=="
+      "integrity": "sha512-DYmSzkr+jToahwWrsiRA2/pzMEtz9Bq1euJwoOuYwuwIYXnZFtHajY2E6a1VNVDc9jP8YUXK1BvnZH9mmT19Zg==",
+      "peer": true
     },
     "@date-io/date-fns": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.16.0.tgz",
       "integrity": "sha512-bfm5FJjucqlrnQcXDVU5RD+nlGmL3iWgkHTq3uAZWVIuBu6dDmGa3m8a6zo2VQQpu8ambq9H22UyUpn7590joA==",
+      "peer": true,
       "requires": {
         "@date-io/core": "^2.16.0"
       }
@@ -34331,6 +34411,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz",
       "integrity": "sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==",
+      "peer": true,
       "requires": {
         "@types/react": "*"
       }
@@ -34339,6 +34420,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
       "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
+      "peer": true,
       "requires": {
         "@types/react": "*"
       }
@@ -35331,6 +35413,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
       "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
+      "peer": true,
       "requires": {
         "core-js": "^2.5.0"
       },
@@ -35338,7 +35421,8 @@
         "core-js": {
           "version": "2.6.12",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "peer": true
         }
       }
     },
@@ -35624,6 +35708,7 @@
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/baseui/-/baseui-12.2.0.tgz",
       "integrity": "sha512-GDooNcxztwg71dkf69bw4Of/nM56adWFvo4VXkU5iVVhLHB0X60ngT+9J2LLOG7F9+s5LQzSXhRO62OiPhLsHA==",
+      "peer": true,
       "requires": {
         "@date-io/date-fns": "^2.6.2",
         "@types/react-virtualized-auto-sizer": "^1.0.0",
@@ -35656,6 +35741,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
           "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+          "peer": true,
           "requires": {
             "regenerator-runtime": "^0.13.11"
           }
@@ -35664,6 +35750,7 @@
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.2.tgz",
           "integrity": "sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==",
+          "peer": true,
           "requires": {
             "@babel/runtime": "^7.12.5"
           }
@@ -36226,6 +36313,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-6.2.0.tgz",
       "integrity": "sha512-1vYv45JaE9NmixZr4dl6ykzbFKv7imI9L7MQDs235b/a7EGbG8rrEsipeHtVvscLSUbl3RX6UP5gyOe0Y2FlHA==",
+      "peer": true,
       "requires": {
         "credit-card-type": "^8.0.0"
       }
@@ -37118,7 +37206,8 @@
     "credit-card-type": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/credit-card-type/-/credit-card-type-8.3.0.tgz",
-      "integrity": "sha512-czfZUpQ7W9CDxZL4yFLb1kFtM/q2lTOY975hL2aO+DC8+GRNDVSXVCHXhVFZPxiUKmQCZbFP8vIhxx5TBQaThw=="
+      "integrity": "sha512-czfZUpQ7W9CDxZL4yFLb1kFtM/q2lTOY975hL2aO+DC8+GRNDVSXVCHXhVFZPxiUKmQCZbFP8vIhxx5TBQaThw==",
+      "peer": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -37313,6 +37402,7 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
       "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
+      "peer": true,
       "requires": {
         "d3-array": "2",
         "d3-axis": "2",
@@ -37350,6 +37440,7 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "peer": true,
       "requires": {
         "internmap": "^1.0.0"
       }
@@ -37357,12 +37448,14 @@
     "d3-axis": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
-      "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw=="
+      "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw==",
+      "peer": true
     },
     "d3-brush": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
       "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+      "peer": true,
       "requires": {
         "d3-dispatch": "1 - 2",
         "d3-drag": "2",
@@ -37375,6 +37468,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
       "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
+      "peer": true,
       "requires": {
         "d3-path": "1 - 2"
       }
@@ -37382,12 +37476,14 @@
     "d3-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "peer": true
     },
     "d3-contour": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
       "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
+      "peer": true,
       "requires": {
         "d3-array": "2"
       }
@@ -37396,6 +37492,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
       "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "peer": true,
       "requires": {
         "delaunator": "4"
       }
@@ -37403,12 +37500,14 @@
     "d3-dispatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
-      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "peer": true
     },
     "d3-drag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
       "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "peer": true,
       "requires": {
         "d3-dispatch": "1 - 2",
         "d3-selection": "2"
@@ -37418,6 +37517,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
       "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "peer": true,
       "requires": {
         "commander": "2",
         "iconv-lite": "0.4",
@@ -37427,19 +37527,22 @@
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "peer": true
         }
       }
     },
     "d3-ease": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
-      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "peer": true
     },
     "d3-fetch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
       "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
+      "peer": true,
       "requires": {
         "d3-dsv": "1 - 2"
       }
@@ -37448,6 +37551,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
       "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "peer": true,
       "requires": {
         "d3-dispatch": "1 - 2",
         "d3-quadtree": "1 - 2",
@@ -37457,12 +37561,14 @@
     "d3-format": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
+      "peer": true
     },
     "d3-geo": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
       "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "peer": true,
       "requires": {
         "d3-array": "^2.5.0"
       }
@@ -37470,12 +37576,14 @@
     "d3-hierarchy": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
-      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==",
+      "peer": true
     },
     "d3-interpolate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
       "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "peer": true,
       "requires": {
         "d3-color": "1 - 2"
       }
@@ -37483,27 +37591,32 @@
     "d3-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
-      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==",
+      "peer": true
     },
     "d3-polygon": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
-      "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
+      "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==",
+      "peer": true
     },
     "d3-quadtree": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
-      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw==",
+      "peer": true
     },
     "d3-random": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
-      "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
+      "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==",
+      "peer": true
     },
     "d3-scale": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
       "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "peer": true,
       "requires": {
         "d3-array": "^2.3.0",
         "d3-format": "1 - 2",
@@ -37516,6 +37629,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
       "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
+      "peer": true,
       "requires": {
         "d3-color": "1 - 2",
         "d3-interpolate": "1 - 2"
@@ -37524,12 +37638,14 @@
     "d3-selection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "peer": true
     },
     "d3-shape": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
       "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "peer": true,
       "requires": {
         "d3-path": "1 - 2"
       }
@@ -37538,6 +37654,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "peer": true,
       "requires": {
         "d3-array": "2"
       }
@@ -37546,6 +37663,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
       "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "peer": true,
       "requires": {
         "d3-time": "1 - 2"
       }
@@ -37553,12 +37671,14 @@
     "d3-timer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
-      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "peer": true
     },
     "d3-transition": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
       "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "peer": true,
       "requires": {
         "d3-color": "1 - 2",
         "d3-dispatch": "1 - 2",
@@ -37571,6 +37691,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
       "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "peer": true,
       "requires": {
         "d3-dispatch": "1 - 2",
         "d3-drag": "2",
@@ -37583,6 +37704,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.21.0"
       },
@@ -37591,6 +37713,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
           "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+          "peer": true,
           "requires": {
             "regenerator-runtime": "^0.13.11"
           }
@@ -37601,6 +37724,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
       "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+      "peer": true,
       "requires": {}
     },
     "debug": {
@@ -37710,7 +37834,8 @@
     "delaunator": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
-      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
+      "peer": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -37758,7 +37883,8 @@
     "detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "peer": true
     },
     "detect-package-manager": {
       "version": "2.0.1",
@@ -37835,6 +37961,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -37844,6 +37971,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
           "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+          "peer": true,
           "requires": {
             "regenerator-runtime": "^0.13.11"
           }
@@ -38995,6 +39123,7 @@
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
       "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
+      "peer": true,
       "requires": {
         "tslib": "^2.0.1"
       }
@@ -39223,6 +39352,7 @@
       "version": "0.11.6",
       "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
       "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "peer": true,
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -40248,8 +40378,7 @@
     "inline-style-expand-shorthand": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/inline-style-expand-shorthand/-/inline-style-expand-shorthand-1.6.0.tgz",
-      "integrity": "sha512-REormb3TCk/CIeL5/Q1rdHYM9tW8YKGKzbvgAH4IXrDsJmq9BnV69yhIGGMzV2IRkR/J6MuLNhY7UfoIJjunog==",
-      "dev": true
+      "integrity": "sha512-REormb3TCk/CIeL5/Q1rdHYM9tW8YKGKzbvgAH4IXrDsJmq9BnV69yhIGGMzV2IRkR/J6MuLNhY7UfoIJjunog=="
     },
     "inline-style-parser": {
       "version": "0.1.1",
@@ -40279,7 +40408,8 @@
     "internmap": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "peer": true
     },
     "interpret": {
       "version": "2.2.0",
@@ -40291,6 +40421,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -41124,7 +41255,8 @@
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "peer": true
     },
     "kind-of": {
       "version": "6.0.3",
@@ -41489,7 +41621,8 @@
     "memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "peer": true
     },
     "memoizerific": {
       "version": "1.11.3",
@@ -41851,7 +41984,8 @@
     "mockdate": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
-      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ=="
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "peer": true
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -42820,7 +42954,8 @@
     "popper.js": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "peer": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -43136,6 +43271,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
       "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "peer": true,
       "requires": {
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
@@ -43319,6 +43455,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -43328,6 +43465,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
       "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.13"
       },
@@ -43336,6 +43474,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
           "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+          "peer": true,
           "requires": {
             "regenerator-runtime": "^0.13.11"
           }
@@ -43388,6 +43527,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -43398,6 +43538,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
       "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
+      "peer": true,
       "requires": {
         "attr-accept": "^1.1.3",
         "file-selector": "^0.1.8",
@@ -43434,6 +43575,7 @@
       "version": "2.9.4",
       "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
       "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.11.6",
@@ -43447,6 +43589,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
       "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "peer": true,
       "requires": {
         "invariant": "^2.2.4",
         "warning": "^4.0.2"
@@ -43471,7 +43614,8 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "peer": true
     },
     "react-merge-refs": {
       "version": "1.1.0",
@@ -43483,12 +43627,14 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/react-movable/-/react-movable-2.5.4.tgz",
       "integrity": "sha512-F+Ml4Il9S7uyY2Nr/UzwnXxWewwsHdQkmwgzAjk+Dsz73sy2yCJk7GkQkdqmh8W6XXTlviepz1VA0eHUWh9MZQ==",
+      "peer": true,
       "requires": {}
     },
     "react-multi-ref": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/react-multi-ref/-/react-multi-ref-1.0.1.tgz",
       "integrity": "sha512-zgQKmduv95vtXIkze6583pRW7Y+mNj7R0bYgxIRWOrsEfxBQaK+MZ6yjTiZ/qcFV4bYGM74nE9isb+YRBNIw2g==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.1.2"
       }
@@ -43497,6 +43643,7 @@
       "version": "1.8.14",
       "resolved": "https://registry.npmjs.org/react-range/-/react-range-1.8.14.tgz",
       "integrity": "sha512-v2nyD5106rHf9dwHzq+WRlhCes83h1wJRHIMFjbZsYYsO6LF4mG/mR3cH7Cf+dkeHq65DItuqIbLn/3jjYjsHg==",
+      "peer": true,
       "requires": {}
     },
     "react-refresh": {
@@ -43509,6 +43656,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.3.3.tgz",
       "integrity": "sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==",
+      "peer": true,
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -43517,6 +43665,7 @@
       "version": "9.22.5",
       "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.5.tgz",
       "integrity": "sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.7.2",
         "clsx": "^1.0.4",
@@ -43530,12 +43679,14 @@
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
       "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
+      "peer": true,
       "requires": {}
     },
     "react-window": {
       "version": "1.8.9",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.9.tgz",
       "integrity": "sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": ">=3.1.1 <6"
@@ -43968,7 +44119,8 @@
     "resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "peer": true
     },
     "resolve": {
       "version": "1.22.2",
@@ -44068,7 +44220,8 @@
     "rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "peer": true
     },
     "safe-array-concat": {
       "version": "1.0.0",
@@ -44358,6 +44511,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -45287,6 +45441,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/styletron-react/-/styletron-react-6.1.0.tgz",
       "integrity": "sha512-PHT5KUaTJKmZdA3W6lV7M+/mgn0+JzuFRiteVZHw3ApLlXwkAZMMy2NwyBwRfx/Q5EZyJvQtoOCif6hY0nVWaA==",
+      "peer": true,
       "requires": {
         "prop-types": "^15.6.0",
         "styletron-standard": "^3.1.0"
@@ -46077,6 +46232,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
       "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "peer": true,
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -46085,6 +46241,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
       "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "peer": true,
       "requires": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
@@ -46344,6 +46501,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "license": "MIT",
   "peerDependencies": {
     "baseui": ">=12.2.0",
-    "styletron-react": ">=6.1.0 < 7",
     "react": ">=17.0.2",
-    "react-dom": ">=17.0.2"
+    "react-dom": ">=17.0.2",
+    "styletron-react": ">=6.1.0 < 7"
   },
   "devDependencies": {
     "@babel/core": "^7.22.1",
@@ -73,7 +73,8 @@
     "access": "public"
   },
   "dependencies": {
-    "inline-style-expand-shorthand": "^1.6.0"
+    "inline-style-expand-shorthand": "^1.6.0",
+    "styletron-standard": "^3.1.0"
   },
   "pre-commit": [
     "tsc",

--- a/src/shared/theme/fonts.ts
+++ b/src/shared/theme/fonts.ts
@@ -1,4 +1,4 @@
-import { StandardEngine } from "styletron-standard";
+import type { StandardEngine } from "styletron-standard";
 import { DefaultFonts } from "./types";
 
 const InterRegularUrl =

--- a/src/shared/theme/fonts.ts
+++ b/src/shared/theme/fonts.ts
@@ -1,4 +1,4 @@
-import StyletronClient from "styletron-engine-atomic/lib/client/client";
+import { StandardEngine } from "styletron-standard";
 import { DefaultFonts } from "./types";
 
 const InterRegularUrl =
@@ -8,12 +8,13 @@ const InterSemiBoldUrl =
 const RobotoMonoRegularUrl =
   "https://fonts.gstatic.com/s/robotomono/v22/L0xuDF4xlVMF-BfR8bXMIhJHg45mwgGEFl0_3vq_ROW4AJi8SJQt.woff2";
 
-export const getDefaultFonts = (instance: StyletronClient): DefaultFonts => {
+export const getDefaultFonts = (instance: StandardEngine): DefaultFonts => {
   const InterRegular = instance.renderFontFace({
     src: `url("${InterRegularUrl}")`,
     fontStyle: "normal",
     fontWeight: 400,
   });
+
   const InterSemiBold = instance.renderFontFace({
     src: `url("${InterSemiBoldUrl}")`,
     fontStyle: "normal",

--- a/src/shared/theme/types.ts
+++ b/src/shared/theme/types.ts
@@ -1,6 +1,6 @@
 import { Primitives } from "baseui/themes/types";
-import StyletronClient from "styletron-engine-atomic/lib/client/client";
 import { Theme } from "baseui";
+import { StandardEngine } from "styletron-standard";
 
 export type DefaultTheme = {
   primitives?: Partial<Primitives>;
@@ -18,4 +18,4 @@ export type CreateThemeOptions = {
   overrides?: any;
 };
 
-export type CreateTheme = (instance: StyletronClient, options?: CreateThemeOptions) => Theme;
+export type CreateTheme = (instance: StandardEngine, options?: CreateThemeOptions) => Theme;

--- a/src/shared/theme/types.ts
+++ b/src/shared/theme/types.ts
@@ -1,6 +1,6 @@
 import { Primitives } from "baseui/themes/types";
 import { Theme } from "baseui";
-import { StandardEngine } from "styletron-standard";
+import type { StandardEngine } from "styletron-standard";
 
 export type DefaultTheme = {
   primitives?: Partial<Primitives>;


### PR DESCRIPTION
This diff removes all imports from `styletron-engine-atomic` except imports in dev mode.
It uses `styletron-standard` instead because it allows package to be styletron engine-agnostic.

`styletron-standard` is shipped by default with `styletron-react`, but i added it to `dependencies` just to make dependencies list more clear.
closes #104 