### PR TITLE
Update baseui version to 13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "vite-plugin-externalize-deps": "^0.6.0"
       },
       "peerDependencies": {
-        "baseui": ">=12.2.0",
+        "baseui": ">=13.0.0 < 14",
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2",
         "styletron-react": ">=6.1.0 < 7"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "baseui": ">=12.2.0",
+    "baseui": ">=13.0.0 < 14",
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2",
     "styletron-react": ">=6.1.0 < 7"


### PR DESCRIPTION
closes #113 

Issue was produced by using baseui version lower than `13`, like `12.2.0`, there was no `onClick` prop on `ListItem`
`< 14` could probably help to avoid such things in the future.