### PR TITLE
Update package version and remove postversion script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nilfoundation/ui-kit",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nilfoundation/ui-kit",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "inline-style-expand-shorthand": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nilfoundation/ui-kit",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "=Nil; Foundation user interface kit",
   "keywords": [
     "ui-kit",
@@ -23,8 +23,7 @@
     "lint": "eslint 'src/**/**/*.{js,ts,mdx}'",
     "tsc": "tsc --noEmit",
     "storybook": "start-storybook -s ./src/assets -p 6006",
-    "build-storybook": "build-storybook",
-    "postversion": "git push --tags"
+    "build-storybook": "build-storybook"
   },
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
Package version is different than existing tags and releases (because of some errors during versioning change), so we need to manually update it.
`postversion` script should be removed, because now we update version automatically after push to master branch