### PR TITLE
Fix Drawer component props

### DIFF
--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -1,24 +1,45 @@
 import { FC } from "react";
-import { ANCHOR, Drawer as BaseDrawer, DrawerProps as BaseDrawerProps } from "baseui/drawer";
+import { ANCHOR, SIZE, Drawer as BaseDrawer, DrawerProps as BaseDrawerProps, DrawerOverrides } from "baseui/drawer";
 import { getDrawerOverrides } from "./overrides";
 import { getMergedOverrides } from "../../shared/utils/getMergedOverrides";
 
-export type DrawerProps = Omit<BaseDrawerProps, "animate" | "closeable"> & {
+type DrawerOwnProps = {
   animate?: boolean;
   closeable?: boolean;
+  overrides?: DrawerOverrides;
+  anchor?: (typeof ANCHOR)[keyof typeof ANCHOR];
+  size?: (typeof SIZE)[keyof typeof SIZE];
+  showBackdrop?: boolean;
+  autoFocus?: boolean;
 };
+
+export type DrawerProps = DrawerOwnProps & Omit<BaseDrawerProps, keyof DrawerOwnProps>;
 
 const Drawer: FC<DrawerProps> = ({
   anchor = ANCHOR.right,
+  size = SIZE.default,
   animate = true,
   closeable = true,
   overrides: baseOverrides,
+  showBackdrop = true,
+  autoFocus = true,
   ...props
 }) => {
   const drawerOverrides = getDrawerOverrides();
   const overrides = getMergedOverrides(drawerOverrides, baseOverrides);
 
-  return <BaseDrawer {...props} anchor={anchor} animate={animate} closeable={closeable} overrides={overrides} />;
+  return (
+    <BaseDrawer
+      {...props}
+      anchor={anchor}
+      size={size}
+      animate={animate}
+      closeable={closeable}
+      showBackdrop={showBackdrop}
+      autoFocus={autoFocus}
+      overrides={overrides}
+    />
+  );
 };
 
 export default Drawer;

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -3,7 +3,7 @@ import { ANCHOR, SIZE, Drawer as BaseDrawer, DrawerProps as BaseDrawerProps, Dra
 import { getDrawerOverrides } from "./overrides";
 import { getMergedOverrides } from "../../shared/utils/getMergedOverrides";
 
-type DrawerOwnProps = {
+export type DrawerOwnProps = {
   animate?: boolean;
   closeable?: boolean;
   overrides?: DrawerOverrides;

--- a/src/components/drawer/index.ts
+++ b/src/components/drawer/index.ts
@@ -1,4 +1,4 @@
 export { default as Drawer } from "./Drawer";
-export type { DrawerProps } from "./Drawer";
+export type { DrawerProps, DrawerOwnProps } from "./Drawer";
 
 export { ANCHOR as DRAWER_ANCHOR, SIZE as DRAWER_SIZE } from "baseui/drawer";


### PR DESCRIPTION
closes #145 

This diff brings some changes to `Drawer` component props.
- `autoFocus`, `showBackdrop`, `size`, `anchor`, `overrides` props are now optional
- `anchor` and `size` could only be type of `DRAWER_ANCHOR` and `DRAWER_SIZE` respectively.