### PR TITLE
Fix code field mobile representation

### DIFF
--- a/src/components/codefield/CodeField.tsx
+++ b/src/components/codefield/CodeField.tsx
@@ -35,6 +35,7 @@ const CodeFieldRenderFunction: ForwardRefRenderFunction<HTMLDivElement, CodeFiel
         extensions={extensions}
         theme={getCodeMirrorTheme(themeOverrides)}
         basicSetup={codeMirrorBasicSetup}
+        className={css(s.codemirrorStyles)}
       />
       {displayCopy && (
         <Button onClick={onCopyIconClick} kind={BUTTON_KIND.secondary} overrides={getCopyButtonOverrides()}>

--- a/src/components/codefield/styles.ts
+++ b/src/components/codefield/styles.ts
@@ -11,10 +11,16 @@ const containerStyles: StyleObject = {
   display: "flex",
   justifyContent: "space-between",
   alignItems: "flex-start",
+  flexWrap: "nowrap",
   gap: "12px",
   color: PRIMITIVE_COLORS.gray100,
 };
 
+const codemirrorStyles: StyleObject = {
+  minWidth: 0,
+};
+
 export const styles = {
   containerStyles,
+  codemirrorStyles,
 };


### PR DESCRIPTION
This diff adds some additional styles to `CodeField` component, fixing issue with displaying component on mobile devices.
If the width of `CodeField` is less than component width, horizontal scrollbar appears. It is completely fine for mobile devices.