### PR TITLE
Remove select duplicate props

### DIFF
--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -1,14 +1,11 @@
 import React from "react";
-import { Select as BaseSelect, SelectProps as BaseSelectProps, Value, SIZE } from "baseui/select";
+import { Select as BaseSelect, SelectProps as BaseSelectProps, SIZE } from "baseui/select";
 import { getSelectOverrides } from "./overrides";
 import { SELECT_SIZE } from "./types";
 import { getMergedOverrides } from "../../shared/utils/getMergedOverrides";
 
 export type SelectProps = Omit<BaseSelectProps, "size"> & {
-  placeholder: React.ReactNode;
-  onChange?: (value: Value) => void;
   size?: SELECT_SIZE;
-  startEnhancer?: React.ReactNode;
 };
 
 const Select: React.FC<SelectProps> = ({


### PR DESCRIPTION
closes #159 

This diff removes non-compatible with baseui props.
`Placeholder` and `onChange` were just redundant, and `startEnchancer` could be edited via overrides, there is `SearchIcon` override for that purpose.
