### PR TITLE
Fix codefiled line numbers color

### DIFF
--- a/src/components/codefield/codeMirrorTheme.ts
+++ b/src/components/codefield/codeMirrorTheme.ts
@@ -12,6 +12,7 @@ const defaultSettings = {
   fontFamily: "Roboto Mono, monospace",
   caret: PRIMITIVE_COLORS.gray100,
   gutterBackground: "transparent",
+  gutterForeground: PRIMITIVE_COLORS.gray400,
 } satisfies CreateThemeOptions["settings"];
 
 const defaultStyles = [

--- a/src/components/codefield/styles.ts
+++ b/src/components/codefield/styles.ts
@@ -13,7 +13,6 @@ const containerStyles: StyleObject = {
   alignItems: "flex-start",
   flexWrap: "nowrap",
   gap: "12px",
-  color: PRIMITIVE_COLORS.gray100,
   transition: "background 0.15s",
   ":hover": {
     background: PRIMITIVE_COLORS.gray800,


### PR DESCRIPTION
closes #163 

This diff uses `codemirror` native theming approach to set line numbers proper color.