### PR TITLE
Add CodeFiled copy button tooltip

### DIFF
--- a/src/components/codefield/CodeField.tsx
+++ b/src/components/codefield/CodeField.tsx
@@ -1,15 +1,13 @@
 import { ForwardRefRenderFunction, forwardRef } from "react";
 import CodeMirror, { ReactCodeMirrorProps } from "@uiw/react-codemirror";
-import { CopyIcon } from "../icons";
-import { BUTTON_KIND, Button } from "../button";
-import { useCopyToClipboard } from "./useCopyToClipboard";
 import { getCodeMirrorTheme } from "./codeMirrorTheme";
 import { useStyletron } from "styletron-react";
 import { styles as s } from "./styles";
 import { getCodeMirrorBasicSetup } from "./codeMirrorBasicSetup";
-import { getCopyButtonOverrides } from "./overrides";
 import { CreateThemeOptions } from "@uiw/codemirror-themes";
 import { prefixLineNumberExtension } from "./prefixLineNumberExtension";
+import { MemoizedCopyButton } from "./CopyButton";
+import { useCopyToClipboard } from "./useCopyToClipboard";
 
 export type CodeFieldProps = {
   code: string;
@@ -25,8 +23,8 @@ const CodeFieldRenderFunction: ForwardRefRenderFunction<HTMLDivElement, CodeFiel
   { code, extensions = [], themeOverrides, displayCopy = true, onCopy, transformOnCopy, showLineNumbers = false },
   ref
 ) => {
-  const onCopyIconClick = useCopyToClipboard(code, onCopy, transformOnCopy);
   const [css] = useStyletron();
+  const copyHandler = useCopyToClipboard(code, onCopy, transformOnCopy);
   const mergedExtensions = [...extensions];
 
   if (showLineNumbers) {
@@ -44,11 +42,7 @@ const CodeFieldRenderFunction: ForwardRefRenderFunction<HTMLDivElement, CodeFiel
         basicSetup={getCodeMirrorBasicSetup(showLineNumbers)}
         className={css(s.codemirrorStyles)}
       />
-      {displayCopy && (
-        <Button onClick={onCopyIconClick} kind={BUTTON_KIND.secondary} overrides={getCopyButtonOverrides()}>
-          <CopyIcon />
-        </Button>
-      )}
+      {displayCopy && <MemoizedCopyButton copyHandler={copyHandler} />}
     </div>
   );
 };

--- a/src/components/codefield/CopyButton.tsx
+++ b/src/components/codefield/CopyButton.tsx
@@ -1,0 +1,34 @@
+import { ACCESSIBILITY_TYPE, PLACEMENT } from "baseui/popover";
+import { BUTTON_KIND, Button } from "../button";
+import { CopyIcon } from "../icons";
+import { StatefulTooltip } from "../tooltip";
+import { getCopyButtonOverrides, getTooltipOverrides } from "./overrides";
+import { memo, useState } from "react";
+
+type CopyButtonProps = {
+  copyHandler: () => boolean;
+};
+
+const CopyButton = ({ copyHandler }: CopyButtonProps) => {
+  const [copied, setCopied] = useState(false);
+  const onClick = () => {
+    const isCopied = copyHandler();
+    setCopied(isCopied);
+  };
+
+  return (
+    <StatefulTooltip
+      content={copied ? "Copied" : "Copy"}
+      accessibilityType={ACCESSIBILITY_TYPE.tooltip}
+      placement={PLACEMENT.bottom}
+      overrides={getTooltipOverrides(copied)}
+      onMouseLeave={() => setCopied(false)}
+    >
+      <Button onClick={onClick} kind={BUTTON_KIND.secondary} overrides={getCopyButtonOverrides()}>
+        <CopyIcon />
+      </Button>
+    </StatefulTooltip>
+  );
+};
+
+export const MemoizedCopyButton = memo(CopyButton);

--- a/src/components/codefield/CopyButton.tsx
+++ b/src/components/codefield/CopyButton.tsx
@@ -23,6 +23,7 @@ const CopyButton = ({ copyHandler }: CopyButtonProps) => {
       placement={PLACEMENT.bottom}
       overrides={getTooltipOverrides(copied)}
       onMouseLeave={() => setCopied(false)}
+      onBlur={() => setCopied(false)}
     >
       <Button onClick={onClick} kind={BUTTON_KIND.secondary} overrides={getCopyButtonOverrides()}>
         <CopyIcon />

--- a/src/components/codefield/overrides.ts
+++ b/src/components/codefield/overrides.ts
@@ -1,4 +1,5 @@
 import { expandProperty } from "inline-style-expand-shorthand";
+import { PRIMITIVE_COLORS } from "../../shared";
 
 export const getCopyButtonOverrides = () => {
   return {
@@ -6,6 +7,25 @@ export const getCopyButtonOverrides = () => {
       style: {
         ...expandProperty("padding", "4px"),
         ...expandProperty("borderRadius", "2px"),
+      },
+    },
+  };
+};
+
+export const getTooltipOverrides = (isCopied: boolean) => {
+  if (!isCopied) {
+    return {};
+  }
+
+  return {
+    Body: {
+      style: {
+        background: PRIMITIVE_COLORS.green200,
+      },
+    },
+    Inner: {
+      style: {
+        background: PRIMITIVE_COLORS.green200,
       },
     },
   };

--- a/src/components/codefield/useCopyToClipboard.ts
+++ b/src/components/codefield/useCopyToClipboard.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { CodeFieldProps } from "./CodeField";
 import copy from "copy-to-clipboard";
 
@@ -6,14 +7,16 @@ export const useCopyToClipboard = (
   onCopy?: CodeFieldProps["onCopy"],
   transformOnCopy?: CodeFieldProps["transformOnCopy"]
 ) => {
-  const onClick = () => {
+  const onClick = useCallback(() => {
     const codeToCopy = transformOnCopy ? transformOnCopy(code) : code;
     const result = copy(codeToCopy);
 
     if (onCopy) {
       onCopy(codeToCopy, result);
     }
-  };
+
+    return result;
+  }, [code, onCopy, transformOnCopy]);
 
   return onClick;
 };


### PR DESCRIPTION
This diff adds tooltip to `CodeField` component copy button.
Tooltip has 2 states - when user hovers over the copy button and when user clicks the button.
The bottleneck was how to preserve clicked state while user still hovers copy button, but to reset state when user stops hovering button.
Native baseui `StatefulTooltip` component has `onMouseLeave` and `onBlur` props, which we used to trigger state change from clicked to normal.

closes #166 