### PR TITLE
Export error page

### DIFF
--- a/src/components/error-page/index.ts
+++ b/src/components/error-page/index.ts
@@ -1,2 +1,8 @@
 export { default as ErrorPage } from "./ErrorPage";
-export type { ErrorPageProps } from "./types";
+export type {
+  ErrorPageProps,
+  ErrorPageWithActionElementProps,
+  ErrorPageWithoutActionElementProps,
+  RedirectProps,
+  ErrorPageBaseProps,
+} from "./types";

--- a/src/components/error-page/types.ts
+++ b/src/components/error-page/types.ts
@@ -1,11 +1,11 @@
 import type { XOR } from "ts-xor";
 
-type ErrorPageBaseProps = {
+export type ErrorPageBaseProps = {
   errorCode: number;
   errorDescription: string;
 };
 
-type ErrorPageWithActionElementProps = {
+export type ErrorPageWithActionElementProps = {
   actionElement?: React.ReactNode;
 } & ErrorPageBaseProps;
 
@@ -14,6 +14,6 @@ export type RedirectProps = {
   redirectTitle: string;
 };
 
-type ErrorPageWithoutActionElementProps = RedirectProps & ErrorPageBaseProps;
+export type ErrorPageWithoutActionElementProps = RedirectProps & ErrorPageBaseProps;
 
 export type ErrorPageProps = XOR<ErrorPageWithActionElementProps, ErrorPageWithoutActionElementProps>;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,3 +26,4 @@ export * from "./list";
 export * from "./drawer";
 export * from "./form-control";
 export * from "./modal";
+export * from "./error-page";


### PR DESCRIPTION
Error page can not be used because it is not exported from the package.