### PR TITLE
improve SPACE and PRIMITIVE_COLORS types

### DIFF
--- a/src/shared/theme/colors.ts
+++ b/src/shared/theme/colors.ts
@@ -70,7 +70,7 @@ export const PRIMITIVE_COLORS = {
   purple900: "#27115D",
 
   mono600: "#292929",
-};
+} as const;
 
 export const createColors = (): DefaultTheme => {
   return {

--- a/src/shared/theme/space.ts
+++ b/src/shared/theme/space.ts
@@ -10,4 +10,4 @@ export const SPACE = {
   64: "64px",
   96: "96px",
   128: "128px",
-};
+} as const;


### PR DESCRIPTION
This diff adds `as const` to SPACE and PRIMITIVE_COLORS in order to enable their value access from the consumer app. Now we can view it only as type `Record<string, string>`, but it will be very helpful to view exact color/space from the app consumer.