### PR TITLE
Fix table props

### DIFF
--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -17,7 +17,7 @@ export enum TABLE_DIVIDER {
   clean = "clean",
 }
 
-export type TableProps = BaseTableProps & {
+export type TableProps = Omit<BaseTableProps, "size" | "divider"> & {
   size?: TABLE_SIZE;
   divider?: TABLE_DIVIDER;
 };


### PR DESCRIPTION
Now it is impossible to specify Table size, because only undefined is allowed as a type.
This happened because of `size` and `divider` prop types intersection with baseui Table props in `TableProps`
#47 