### PR TITLE
Make ts-xor peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "baseui": ">=13.0.0 < 14",
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2",
-    "styletron-react": ">=6.1.0 < 7"
+    "styletron-react": ">=6.1.0 < 7",
+    "ts-xor": ">=1.1.0 < 2"
   },
   "devDependencies": {
     "@babel/core": "^7.22.1",
@@ -66,7 +67,6 @@
     "size-limit": "^9.0.0",
     "storybook-addon-designs": "^6.3.1",
     "styletron-engine-atomic": "^1.5.0",
-    "ts-xor": "^1.1.0",
     "typescript": "4.9.5",
     "vite": "^4.3.9",
     "vite-plugin-dts": "^2.3.0",


### PR DESCRIPTION
Now some component's types don't work correctly, because ts-xor package is not installed with ui-kit package.