### PR TITLE
Dont use const enum TOOLTIP_KIND

### DIFF
--- a/src/components/tooltip/types.ts
+++ b/src/components/tooltip/types.ts
@@ -1,4 +1,4 @@
-export const enum TOOLTIP_KIND {
+export enum TOOLTIP_KIND {
   DEFAULT = "default",
   ERROR = "error",
   SUCCESS = "success",


### PR DESCRIPTION
This diff makes TOOLTIP_KIND usual enum, because const enum produces side effects in consumer app.