### PR TITLE
Make inter medium font link correct

### DIFF
--- a/src/shared/theme/fonts.ts
+++ b/src/shared/theme/fonts.ts
@@ -6,7 +6,7 @@ const InterRegularUrl =
 const InterSemiBoldUrl =
   "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuGKYAZ9hiJ-Ek-_EeA.woff2";
 const InterMediumUrl =
-  "https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuI6fAZJhiJ-Ek-_EeAmM.woff2";
+  "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuI6fAZJhiJ-Ek-_EeA.woff2";
 const RobotoMonoRegularUrl =
   "https://fonts.gstatic.com/s/robotomono/v22/L0xuDF4xlVMF-BfR8bXMIhJHg45mwgGEFl0_3vq_ROW4AJi8SJQt.woff2";
 


### PR DESCRIPTION
This diff removes extra symbols in link for downloading Inter Medium font.