### PR TITLE
Remove input kind error

### DIFF
--- a/src/components/form-control/FormControl.stories.mdx
+++ b/src/components/form-control/FormControl.stories.mdx
@@ -63,9 +63,6 @@ export const InputFieldProps = {
   <Story name="Error" args={{ ...InputFieldProps, error: true, size: INPUT_SIZE.small }}>
     {Template.bind({})}
   </Story>
-  <Story name="Positive" args={{ ...InputFieldProps, positive: true, size: INPUT_SIZE.small }}>
-    {Template.bind({})}
-  </Story>
   <Story name="With Max Length" args={{ ...InputFieldProps, isCounter: true, size: INPUT_SIZE.small }}>
     {Template.bind({})}
   </Story>

--- a/src/components/form-control/FormControl.tsx
+++ b/src/components/form-control/FormControl.tsx
@@ -9,7 +9,7 @@ export interface ICounter {
   length: number;
 }
 
-export type FormControlProps = Omit<BaseFormControlProps, "counter"> & {
+export type FormControlProps = Omit<BaseFormControlProps, "counter" | "positive"> & {
   size?: INPUT_SIZE;
   readOnly?: boolean;
   isLoading?: boolean;

--- a/src/components/form-control/overrides.tsx
+++ b/src/components/form-control/overrides.tsx
@@ -3,17 +3,16 @@ import { FormControlOverrides } from "baseui/form-control";
 import { PRIMITIVE_COLORS } from "../../shared";
 import FormControlLabel from "./ui/FormControlLabel";
 
-const getCaptionColor = (isError: boolean, isPositive: boolean, isDisabled: boolean): string => {
+const getCaptionColor = (isError: boolean, isDisabled: boolean): string => {
   if (isDisabled) {
-    return PRIMITIVE_COLORS.gray300;
+    return PRIMITIVE_COLORS.gray400;
   }
+
   if (isError) {
-    return PRIMITIVE_COLORS.red400;
+    return PRIMITIVE_COLORS.red500;
   }
-  if (isPositive) {
-    return PRIMITIVE_COLORS.green400;
-  }
-  return PRIMITIVE_COLORS.gray300;
+
+  return PRIMITIVE_COLORS.gray200;
 };
 
 export const getFormControlOverrides = (
@@ -28,8 +27,8 @@ export const getFormControlOverrides = (
       ),
     },
     Caption: {
-      style: ({ $error, $positive, $disabled }) => ({
-        color: getCaptionColor($error, $positive, $disabled),
+      style: ({ $error, $disabled }) => ({
+        color: getCaptionColor($error, $disabled),
       }),
     },
   };

--- a/src/components/input/Input.stories.mdx
+++ b/src/components/input/Input.stories.mdx
@@ -35,6 +35,17 @@ export const Template = ({ value: baseValue, ...args }) => {
   <Story name="Disabled" args={{ placeholder: "Disabled Field", disabled: true, size: INPUT_SIZE.small }}>
     {Template.bind({})}
   </Story>
+  <Story
+    name="Secondary disabled"
+    args={{
+      placeholder: "Disabled Secondary Field",
+      disabled: true,
+      size: INPUT_SIZE.small,
+      kind: INPUT_KIND.secondary,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
   <Story name="Readonly" args={{ placeholder: "Readonly Field", readOnly: true, size: INPUT_SIZE.small }}>
     {Template.bind({})}
   </Story>
@@ -44,7 +55,7 @@ export const Template = ({ value: baseValue, ...args }) => {
   <Story name="Secondary" args={{ placeholder: "Secondary input", size: INPUT_SIZE.small, kind: INPUT_KIND.secondary }}>
     {Template.bind({})}
   </Story>
-  <Story name="Error" args={{ placeholder: "Error Field", size: INPUT_SIZE.small, kind: INPUT_KIND.error }}>
+  <Story name="Error" args={{ placeholder: "Error Field", size: INPUT_SIZE.small, error: true }}>
     {Template.bind({})}
   </Story>
   <Story
@@ -65,7 +76,10 @@ export const Template = ({ value: baseValue, ...args }) => {
   >
     {Template.bind({})}
   </Story>
-  <Story name="Clearable" args={{ placeholder: "Clearable. Type something to check", clearable: true, size: INPUT_SIZE.small }}>
+  <Story
+    name="Clearable"
+    args={{ placeholder: "Clearable. Type something to check", clearable: true, size: INPUT_SIZE.small }}
+  >
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/input/overrides.tsx
+++ b/src/components/input/overrides.tsx
@@ -1,42 +1,47 @@
 import { InputOverrides } from "baseui/input";
-import { inputContainerModifiedStyles, inputDisabledStyles, inputModifiedStyles } from "./styles";
+import { inputContainerModifiedStyles, inputModifiedStyles } from "./styles";
 import { INPUT_KIND, INPUT_SIZE } from "./types";
 import { PRIMITIVE_COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { StyleObject } from "styletron-standard";
 
-const getColor = (isFocused: boolean, kind: INPUT_KIND): string => {
+const getColor = (isFocused: boolean, error: boolean, disabled: boolean): string => {
   if (isFocused) {
     return PRIMITIVE_COLORS.gray50;
   }
-  if (kind === INPUT_KIND.error) {
+
+  if (error) {
     return PRIMITIVE_COLORS.red500;
+  }
+
+  if (disabled) {
+    return PRIMITIVE_COLORS.gray400;
   }
 
   return PRIMITIVE_COLORS.gray200;
 };
 
-const getBorderStyle = (isFocused: boolean, kind: INPUT_KIND): StyleObject => {
+const getBorderStyle = (isFocused: boolean, kind: INPUT_KIND, error: boolean): StyleObject => {
   if (isFocused) {
     return {
-      borderColor: PRIMITIVE_COLORS.gray50,
+      ...expandProperty("borderColor", PRIMITIVE_COLORS.gray50),
     };
   }
 
-  if (kind === INPUT_KIND.error) {
+  if (error) {
     return {
-      borderColor: PRIMITIVE_COLORS.red500,
+      ...expandProperty("borderColor", PRIMITIVE_COLORS.red500),
     };
   }
 
   if (kind === INPUT_KIND.secondary) {
     return {
-      borderColor: PRIMITIVE_COLORS.gray900,
+      ...expandProperty("borderColor", PRIMITIVE_COLORS.gray900),
     };
   }
 
   return {
-    borderColor: PRIMITIVE_COLORS.gray800,
+    ...expandProperty("borderColor", PRIMITIVE_COLORS.gray800),
   };
 };
 
@@ -52,13 +57,19 @@ const getBackgroundColor = (kind: INPUT_KIND): StyleObject => {
   };
 };
 
-const getHoverStyles = (kind: INPUT_KIND): StyleObject => {
-  const transition = "background-color 0.15s ease-in-out";
+const getHoverStyles = (kind: INPUT_KIND, disabled: boolean, isFocused: boolean): StyleObject => {
+  if (disabled) {
+    return {};
+  }
+
+  const transition = "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out";
+
   if (kind === INPUT_KIND.secondary) {
     return {
       transition,
       ":hover": {
         backgroundColor: PRIMITIVE_COLORS.gray800,
+        ...(!isFocused ? expandProperty("borderColor", PRIMITIVE_COLORS.gray800) : {}),
       },
     };
   }
@@ -67,6 +78,7 @@ const getHoverStyles = (kind: INPUT_KIND): StyleObject => {
     transition,
     ":hover": {
       backgroundColor: PRIMITIVE_COLORS.gray700,
+      ...(!isFocused ? expandProperty("borderColor", PRIMITIVE_COLORS.gray700) : {}),
     },
   };
 };
@@ -74,56 +86,54 @@ const getHoverStyles = (kind: INPUT_KIND): StyleObject => {
 export const getInputOverrides = (size: INPUT_SIZE, kind: INPUT_KIND): InputOverrides => {
   return {
     Root: {
-      style: ({ $disabled, $isFocused }) => ({
+      style: ({ $disabled, $isFocused, $error }) => ({
         ...getBackgroundColor(kind),
         ...inputContainerModifiedStyles[size],
-        ...($disabled ? inputDisabledStyles : {}),
-        ...getBorderStyle($isFocused, kind),
-        ...getHoverStyles(kind),
+        ...getBorderStyle($isFocused, kind, $error),
+        ...getHoverStyles(kind, $disabled, $isFocused),
       }),
     },
     InputContainer: {
-      style: ({ $disabled }) => ({
+      style: {
         backgroundColor: "transparent",
-        ...($disabled ? inputDisabledStyles : {}),
-      }),
+      },
     },
     Input: {
-      style: ({ $isFocused }) => ({
+      style: ({ $isFocused, $error, $disabled }) => ({
         ...inputModifiedStyles[size],
-        color: getColor($isFocused, kind),
+        color: getColor($isFocused, $error, $disabled),
         "-webkit-text-fill-color": "unset",
 
         "::placeholder": {
-          color: getColor($isFocused, kind),
+          color: getColor($isFocused, $error, $disabled),
         },
       }),
     },
     StartEnhancer: {
-      style: ({ $error, $isFocused }) => ({
+      style: ({ $error, $isFocused, $disabled }) => ({
         backgroundColor: "transparent",
-        color: getColor($error, $isFocused),
+        color: getColor($isFocused, $error, $disabled),
         ...expandProperty("padding", "0 12px 0 0"),
       }),
     },
     EndEnhancer: {
-      style: ({ $error, $isFocused }) => ({
+      style: ({ $error, $isFocused, $disabled }) => ({
         backgroundColor: "transparent",
         ...expandProperty("padding", "0 0 0 12px"),
-        color: getColor($error, $isFocused),
+        color: getColor($isFocused, $error, $disabled),
       }),
     },
     ClearIcon: {
       props: {
         size: "22px",
       },
-      style: ({ $error, $isFocused }) => ({
-        color: getColor($error, $isFocused),
+      style: ({ $error, $isFocused, $disabled }) => ({
+        color: getColor($isFocused, $error, $disabled),
       }),
     },
     MaskToggleButton: {
-      style: ({ $error, $isFocused }) => ({
-        color: getColor($error, $isFocused),
+      style: ({ $error, $isFocused, $disabled }) => ({
+        color: getColor($isFocused, $error, $disabled),
         cursor: "pointer",
       }),
     },

--- a/src/components/input/styles.ts
+++ b/src/components/input/styles.ts
@@ -1,5 +1,4 @@
 import { INPUT_SIZE } from "./types";
-import { PRIMITIVE_COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 
 export const inputContainerModifiedStyles = {
@@ -24,12 +23,6 @@ export const inputModifiedStyles = {
     lineHeight: "22px",
     ...expandProperty("padding", "12px 0"),
   },
-};
-
-export const inputDisabledStyles = {
-  backgroundColor: "transparent",
-  ...expandProperty("borderColor", PRIMITIVE_COLORS.gray600),
-  color: PRIMITIVE_COLORS.gray500,
 };
 
 export const spinnerStyles = {

--- a/src/components/input/types.ts
+++ b/src/components/input/types.ts
@@ -6,5 +6,4 @@ export enum INPUT_SIZE {
 export enum INPUT_KIND {
   primary = "primary",
   secondary = "secondary",
-  error = "error",
 }

--- a/src/components/textarea/Textarea.stories.mdx
+++ b/src/components/textarea/Textarea.stories.mdx
@@ -34,9 +34,6 @@ export const Template = ({ value: baseValue, ...args }) => {
   <Story name="Resizable" args={{ placeholder: "Resizable Field", resize: "both" }}>
     {Template.bind({})}
   </Story>
-  <Story name="Positive" args={{ placeholder: "Positive Field", positive: true }}>
-    {Template.bind({})}
-  </Story>
   <Story name="Error" args={{ placeholder: "Error Field", error: true }}>
     {Template.bind({})}
   </Story>

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -7,7 +7,7 @@ import { useStyletron } from "baseui";
 import TextareaSpinner from "./ui/TextareaSpinner";
 import { getMergedOverrides } from "../../shared/utils/getMergedOverrides";
 
-export type TextareaProps = BaseTextareaProps & {
+export type TextareaProps = Omit<BaseTextareaProps, "positive"> & {
   size?: TEXTAREA_SIZE;
   isLoading?: boolean;
 };


### PR DESCRIPTION
- Input styles fixes according with the system https://www.figma.com/file/YjE625ScDMf2ILjWB1sTMc/System?type=design&node-id=171-322302&mode=design&t=7iAjX8BRpkgVcg9E-0
- Add styles to disabled inputs.
- Remove input kind error and replace it with base-ui compatible `error` prop