### PR TITLE
UseImperativeHandle for series, scales and price line

### DIFF
--- a/src/components/chart/priceLine/PriceLine.tsx
+++ b/src/components/chart/priceLine/PriceLine.tsx
@@ -1,10 +1,14 @@
-import { PriceLineProps } from "./types";
+import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
+import { PriceLineApiRef, PriceLineProps } from "./types";
 import { useInitPriceLine } from "./useInitPriceLine";
 
-const PriceLine = (props: PriceLineProps) => {
-  useInitPriceLine(props);
+const PriceLineRenderFunction = (props: PriceLineProps, ref: ForwardedRef<PriceLineApiRef>) => {
+  const priceLineApiRef = useInitPriceLine(props);
+  useImperativeHandle(ref, () => priceLineApiRef.current, [priceLineApiRef]);
 
   return null;
 };
 
+const PriceLine = forwardRef(PriceLineRenderFunction);
+PriceLine.displayName = "PriceLine";
 export default PriceLine;

--- a/src/components/chart/priceLine/types.ts
+++ b/src/components/chart/priceLine/types.ts
@@ -3,7 +3,6 @@ import { IPriceLine, PriceLineOptions } from "lightweight-charts";
 export type PriceLineProps = {
   price: number;
   options?: Omit<Partial<PriceLineOptions>, "price">;
-  onInit?: (priceLine: IPriceLine) => void;
 };
 
 export type PriceLineApiRef = {

--- a/src/components/chart/priceLine/useInitPriceLine.ts
+++ b/src/components/chart/priceLine/useInitPriceLine.ts
@@ -3,7 +3,7 @@ import { PriceLineApiRef, PriceLineProps } from "./types";
 import { SeriesContext } from "../series/SeriesContext";
 import { priceLineDefaultOptions } from "./priceLineDefaultOptions";
 
-export const useInitPriceLine = ({ options, onInit, price }: PriceLineProps) => {
+export const useInitPriceLine = ({ options, price }: PriceLineProps) => {
   const series = useContext(SeriesContext);
 
   if (!series) {
@@ -39,11 +39,6 @@ export const useInitPriceLine = ({ options, onInit, price }: PriceLineProps) => 
 
   useLayoutEffect(() => {
     priceLineApiRef.current.api();
-
-    if (onInit) {
-      const priceLine = priceLineApiRef.current.api();
-      priceLine && onInit(priceLine);
-    }
 
     return () => {
       priceLineApiRef.current.clear();

--- a/src/components/chart/scales/PriceScale.tsx
+++ b/src/components/chart/scales/PriceScale.tsx
@@ -1,9 +1,14 @@
-import { PriceScaleProps } from "./types";
+import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
+import { PriceScaleApiRef, PriceScaleProps } from "./types";
 import { useInitPriceScale } from "./useInitPriceScale";
 
-const PriceScale = (props: PriceScaleProps) => {
-  useInitPriceScale(props);
+const PriceScaleRenderFunction = (props: PriceScaleProps, ref: ForwardedRef<PriceScaleApiRef>) => {
+  const priceScaleApiRef = useInitPriceScale(props);
+  useImperativeHandle(ref, () => priceScaleApiRef.current, [priceScaleApiRef]);
+
   return null;
 };
 
+const PriceScale = forwardRef(PriceScaleRenderFunction);
+PriceScale.displayName = "PriceScale";
 export default PriceScale;

--- a/src/components/chart/scales/TimeScale.tsx
+++ b/src/components/chart/scales/TimeScale.tsx
@@ -1,9 +1,14 @@
-import { TimeScaleProps } from "./types";
+import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
+import { TimeScaleApiRef, TimeScaleProps } from "./types";
 import { useInitTimeScale } from "./useInitTimeScale";
 
-const TimeScale = (props: TimeScaleProps) => {
-  useInitTimeScale(props);
+const TimeScaleRenderFunction = (props: TimeScaleProps, ref: ForwardedRef<TimeScaleApiRef>) => {
+  const timeScaleApiRef = useInitTimeScale(props);
+  useImperativeHandle(ref, () => timeScaleApiRef.current, [timeScaleApiRef]);
+
   return null;
 };
 
+const TimeScale = forwardRef(TimeScaleRenderFunction);
+TimeScale.displayName = "TimeScale";
 export default TimeScale;

--- a/src/components/chart/scales/types.ts
+++ b/src/components/chart/scales/types.ts
@@ -34,11 +34,9 @@ export type TimeScaleProps = {
   visibleRange?: Range<Time>;
   visibleLogicalRange?: Range<number>;
   options?: TimeScaleOptions;
-  onInit?: (timeScale: ITimeScaleApi<Time>) => void;
 };
 
 export type PriceScaleProps = {
   options?: PriceScaleOptions;
   id: string;
-  onInit?: (priceScale: IPriceScaleApi) => void;
 };

--- a/src/components/chart/scales/useInitPriceScale.ts
+++ b/src/components/chart/scales/useInitPriceScale.ts
@@ -3,7 +3,7 @@ import { ChartContext } from "../ChartContext";
 import { PriceScaleProps, PriceScaleApiRef } from "./types";
 import { priceScaleDefaultOptions } from "./scalesDefaultOptions";
 
-export const useInitPriceScale = ({ options, id, onInit }: PriceScaleProps) => {
+export const useInitPriceScale = ({ options, id }: PriceScaleProps) => {
   const chart = useContext(ChartContext);
 
   if (!chart) {
@@ -47,11 +47,6 @@ export const useInitPriceScale = ({ options, id, onInit }: PriceScaleProps) => {
 
   useLayoutEffect(() => {
     priceScaleApiRef.current.api();
-
-    if (onInit) {
-      const priceScale = priceScaleApiRef.current.api();
-      priceScale && onInit(priceScale);
-    }
 
     return () => {
       priceScaleApiRef.current.clear();

--- a/src/components/chart/scales/useInitTimeScale.ts
+++ b/src/components/chart/scales/useInitTimeScale.ts
@@ -10,7 +10,6 @@ export const useInitTimeScale = ({
   visibleRange,
   visibleLogicalRange,
   options,
-  onInit,
 }: TimeScaleProps) => {
   const chart = useContext(ChartContext);
 
@@ -55,11 +54,6 @@ export const useInitTimeScale = ({
 
   useLayoutEffect(() => {
     timeScaleApiRef.current.api();
-
-    if (onInit) {
-      const timeScale = timeScaleApiRef.current.api();
-      timeScale && onInit(timeScale);
-    }
 
     return () => {
       timeScaleApiRef.current.clear();

--- a/src/components/chart/series/SeriesTemplate.tsx
+++ b/src/components/chart/series/SeriesTemplate.tsx
@@ -1,11 +1,18 @@
 import { useInitSeries } from "./useInitSeries";
-import { SeriesType, SeriesTemplateProps } from "./types";
+import { SeriesType, SeriesTemplateProps, SeriesApiRef } from "./types";
 import { SeriesContext } from "./SeriesContext";
+import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
 
-export const SeriesTemplate = <T extends SeriesType = "Line">({ children, ...rest }: SeriesTemplateProps<T>) => {
+const SeriesTemplateRenderFunction = <T extends SeriesType = "Line">(
+  { children, ...rest }: SeriesTemplateProps<T>,
+  ref: ForwardedRef<SeriesApiRef<T>>
+) => {
   const seriesApi = useInitSeries(rest);
+  useImperativeHandle(ref, () => seriesApi.current, [seriesApi]);
 
   return <SeriesContext.Provider value={seriesApi.current}>{children}</SeriesContext.Provider>;
 };
 
+const SeriesTemplate = forwardRef(SeriesTemplateRenderFunction);
+SeriesTemplate.displayName = "SeriesTemplate";
 export default SeriesTemplate;

--- a/src/components/chart/series/types.ts
+++ b/src/components/chart/series/types.ts
@@ -20,7 +20,6 @@ export type SeriesParameters<T extends SeriesType> = {
 export type SeriesTemplateProps<T extends SeriesType> = {
   type: T;
   children?: ReactNode;
-  onInit?: (series: ISeriesApi<T>) => void;
 } & SeriesParameters<T>;
 
 export type SeriesApiRef<T extends SeriesType> = {

--- a/src/components/chart/series/useInitSeries.ts
+++ b/src/components/chart/series/useInitSeries.ts
@@ -10,7 +10,6 @@ export const useInitSeries = <T extends SeriesType>({
   options,
   reactive,
   markers,
-  onInit,
 }: Omit<SeriesTemplateProps<T>, "children">) => {
   const chart = useContext(ChartContext);
 
@@ -56,11 +55,6 @@ export const useInitSeries = <T extends SeriesType>({
 
   useLayoutEffect(() => {
     seriesApiRef.current.api();
-
-    if (onInit) {
-      const series = seriesApiRef.current.api();
-      series && onInit(series);
-    }
 
     return () => {
       seriesApiRef.current.clear();


### PR DESCRIPTION
This diff changes Chart elements' api a bit. It removes `onInit` prop and adds `useImperativeHandle` instead. Both are not perfect, but second approach looks more react way.