### PR TITLE
Replace process in standalone build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@microsoft/api-extractor": "^7.34.9",
+        "@rollup/plugin-replace": "^5.0.5",
         "@size-limit/preset-big-lib": "^9.0.0",
         "@storybook/addon-actions": "^7.5.3",
         "@storybook/addon-designs": "^7.0.5",
@@ -4006,6 +4007,39 @@
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
+      "integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@microsoft/api-extractor": "^7.34.9",
+    "@rollup/plugin-replace": "^5.0.5",
     "@size-limit/preset-big-lib": "^9.0.0",
     "@storybook/addon-actions": "^7.5.3",
     "@storybook/addon-designs": "^7.0.5",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { resolve } from 'path';
 import dts from 'vite-plugin-dts';
 import { externalizeDeps } from 'vite-plugin-externalize-deps';
 import eslint from 'vite-plugin-eslint';
+import replace from '@rollup/plugin-replace';
 
 const packageJson = require('./package.json');
 
@@ -62,6 +63,14 @@ export default defineConfig(({mode}) => {
             'react-dom': 'ReactDOM',
           } : undefined,
         },
+        plugins: [
+          replace({
+            preventAssignment: true,
+            values: {
+              'process.env.NODE_ENV': JSON.stringify('production')
+            }
+          })
+        ],
       },
       outDir: 'dist',
       emptyOutDir: !isStandalone,


### PR DESCRIPTION
This diff add rollup replace plugin to replace `process.env.NODE_ENV` in standalone build.