### PR TITLE
Add ssr tests for components

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,3 @@
 import "@testing-library/jest-dom";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+global.TextEncoder = require("util").TextEncoder;

--- a/src/components/accordion/Accordion.test.tsx
+++ b/src/components/accordion/Accordion.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import Accordion from "./Accordion";
 import Panel from "./Panel";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 const text = "Text";
 
@@ -15,6 +16,14 @@ describe("Accordion", () => {
 
     const accordionContent = screen.getByText(text);
     expect(accordionContent).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <Accordion renderAll>
+        <Panel title="Panel 1">{text}</Panel>
+      </Accordion>
+    );
   });
 
   // Add more tests as needed

--- a/src/components/badge/Badge.test.tsx
+++ b/src/components/badge/Badge.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import Badge from "./Badge";
 import { BADGE_COLOR } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 const content = "Badge";
 
@@ -11,6 +12,22 @@ describe("Badge", () => {
 
     const badgeElement = screen.getByText(content);
     expect(badgeElement).toBeInTheDocument();
+  });
+
+  it("handles color prop", () => {
+    const { rerender } = render(<Badge content={content} color={BADGE_COLOR.accent} />);
+
+    let badgeElement = screen.getByText(content);
+    expect(badgeElement).toBeInTheDocument();
+
+    rerender(<Badge content={content} color={BADGE_COLOR.positive} />);
+
+    badgeElement = screen.getByText(content);
+    expect(badgeElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Badge content={content} color={BADGE_COLOR.accent} />);
   });
 
   // Add more tests as needed

--- a/src/components/breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.test.tsx
@@ -1,10 +1,21 @@
 import { render } from "../../test-utils/render";
 import Breadcrumbs from "./Breadcrumbs";
 import BreadcrumbsItem from "./BreadcrumbsItem";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Breadcrumbs", () => {
   it("renders without crashing", () => {
     render(
+      <Breadcrumbs>
+        <BreadcrumbsItem href="#">Parent Page</BreadcrumbsItem>
+        <BreadcrumbsItem href="#">Sub-Parent Page</BreadcrumbsItem>
+        <BreadcrumbsItem isActive>Current Page</BreadcrumbsItem>
+      </Breadcrumbs>
+    );
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
       <Breadcrumbs>
         <BreadcrumbsItem href="#">Parent Page</BreadcrumbsItem>
         <BreadcrumbsItem href="#">Sub-Parent Page</BreadcrumbsItem>

--- a/src/components/button-icon/ButtonIcon.test.tsx
+++ b/src/components/button-icon/ButtonIcon.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import ButtonIcon from "./ButtonIcon";
 import { BUTTON_SIZE } from "../button/types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("ButtonIcon", () => {
   it("renders without crashing", () => {
@@ -20,6 +21,12 @@ describe("ButtonIcon", () => {
     userEvent.click(buttonElement);
 
     await waitFor(() => expect(handleClick).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <ButtonIcon size={BUTTON_SIZE.default} data-testid="Test Button" icon={<span>Icon</span>}></ButtonIcon>
+    );
   });
 
   // Add more tests as needed

--- a/src/components/button/Button.test.tsx
+++ b/src/components/button/Button.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import Button from "./Button";
 import { BUTTON_KIND } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Button", () => {
   it("renders without crashing", () => {
@@ -20,6 +21,10 @@ describe("Button", () => {
 
     userEvent.click(buttonElement);
     await waitFor(() => expect(handleClick).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Button kind={BUTTON_KIND.secondary}>Test Button</Button>);
   });
 
   // Add more tests as needed

--- a/src/components/card/Card.test.tsx
+++ b/src/components/card/Card.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import Card from "./Card";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Card", () => {
   it("renders without crashing", () => {
@@ -8,6 +9,10 @@ describe("Card", () => {
 
     const cardElement = screen.getByText(/Test Card/i);
     expect(cardElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Card>Test Card</Card>);
   });
 
   // Add more tests as needed

--- a/src/components/chart/Chart.test.tsx
+++ b/src/components/chart/Chart.test.tsx
@@ -3,6 +3,7 @@ import Chart from "./ChartWrapper";
 import { LineSeries } from "./series";
 import { MockViewport, mockViewport } from "jsdom-testing-mocks";
 import { setupJestCanvasMock } from "jest-canvas-mock";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 let viewport: MockViewport;
 
@@ -38,6 +39,14 @@ const lineData = [
 describe("Chart", () => {
   it("renders without crashing", () => {
     render(
+      <Chart height={400}>
+        <LineSeries data={lineData} />
+      </Chart>
+    );
+  });
+
+  it("renders without crashing in SSR", () => {
+    createComponentSSRTest(
       <Chart height={400}>
         <LineSeries data={lineData} />
       </Chart>

--- a/src/components/checkbox/Checkbox.test.tsx
+++ b/src/components/checkbox/Checkbox.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Checkbox, { LABEL_PLACEMENT } from "./Checkbox";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Checkbox", () => {
   it("renders without crashing", () => {
@@ -19,6 +20,10 @@ describe("Checkbox", () => {
     userEvent.click(checkboxElement);
 
     await waitFor(() => expect(handleChange).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Checkbox labelPlacement={LABEL_PLACEMENT.right}>Test Checkbox</Checkbox>);
   });
 
   // Add more tests as needed

--- a/src/components/codefield/CodeField.test.tsx
+++ b/src/components/codefield/CodeField.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import CodeField from "./CodeField";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("CodeField", () => {
   it("renders without crashing", () => {
@@ -8,6 +9,10 @@ describe("CodeField", () => {
 
     const codeElement = screen.getByText(/Test Code/i);
     expect(codeElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<CodeField code="Test Code" />);
   });
 
   // Add more tests as needed

--- a/src/components/drawer/Drawer.test.tsx
+++ b/src/components/drawer/Drawer.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import Drawer from "./Drawer";
 import { ANCHOR, SIZE } from "baseui/drawer";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Drawer", () => {
   it("renders without crashing", () => {
@@ -13,6 +14,34 @@ describe("Drawer", () => {
 
     const drawerElement = screen.getByText(/Test Drawer/i);
     expect(drawerElement).toBeInTheDocument();
+  });
+
+  it("handles custom anchor and size", async () => {
+    const { rerender } = render(
+      <Drawer isOpen anchor={ANCHOR.right} size={SIZE.default}>
+        Test Drawer
+      </Drawer>
+    );
+
+    let drawerElement = screen.getByText(/Test Drawer/i);
+    expect(drawerElement).toBeInTheDocument();
+
+    rerender(
+      <Drawer isOpen anchor={ANCHOR.left} size={SIZE.full}>
+        Test Drawer
+      </Drawer>
+    );
+
+    drawerElement = screen.getByText(/Test Drawer/i);
+    expect(drawerElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <Drawer isOpen anchor={ANCHOR.right} size={SIZE.default}>
+        Test Drawer
+      </Drawer>
+    );
   });
 
   // Add more tests as needed

--- a/src/components/error-page/ErrorPage.test.tsx
+++ b/src/components/error-page/ErrorPage.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import ErrorPage from "./ErrorPage";
 import { MockViewport, mockViewport } from "jsdom-testing-mocks";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 let viewport: MockViewport;
 
@@ -22,6 +23,12 @@ describe("ErrorPage", () => {
 
     const errorDescriptionElement = screen.getByText(/Page not found/i);
     expect(errorDescriptionElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <ErrorPage errorCode={404} errorDescription="Page not found" redirectTitle="Go back" redirectPath="/" />
+    );
   });
 
   // Add more tests as needed

--- a/src/components/error-page/useIsMobile.ts
+++ b/src/components/error-page/useIsMobile.ts
@@ -1,31 +1,30 @@
-import { useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { mobileScreenMaxWidth } from "./styles";
-import { debounce } from "../../shared/utils/debounce";
-import { useOnWindowResize } from "../../shared/hooks/useOnWindowResize";
-import { isBrowser } from "../../shared/utils/isBrowser";
 
 const getUniversalMediaQueryMobile = () => {
-  if (!isBrowser()) {
-    return null;
-  }
-
   return window.matchMedia(`(max-width: ${mobileScreenMaxWidth}px)`);
 };
 
-const getisMobile = (): boolean => {
-  const mediaQueryMobile = getUniversalMediaQueryMobile();
-  return mediaQueryMobile ? mediaQueryMobile.matches : false;
-};
-
 export const useIsMobile = () => {
-  const [isMobile, setIsMobile] = useState<boolean>(getisMobile());
+  const [isMobile, setIsMobile] = useState<boolean>(true);
 
-  const resize = debounce(() => {
-    const newIsMobileValue = getisMobile();
-    isMobile !== newIsMobileValue && setIsMobile(newIsMobileValue);
-  }, 100);
+  useLayoutEffect(() => {
+    const mediaQueryMobile = getUniversalMediaQueryMobile();
 
-  useOnWindowResize(resize);
+    if (!mediaQueryMobile) {
+      return;
+    }
+
+    const listener = () => {
+      setIsMobile(mediaQueryMobile.matches);
+    };
+
+    mediaQueryMobile.addEventListener("change", listener);
+
+    return () => {
+      mediaQueryMobile.removeEventListener("change", listener);
+    };
+  }, []);
 
   return isMobile;
 };

--- a/src/components/file-uploader/FileUploader.test.tsx
+++ b/src/components/file-uploader/FileUploader.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import FileUploader from "./FileUploader";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("FileUploader", () => {
   it("renders without crashing", () => {
@@ -9,5 +10,10 @@ describe("FileUploader", () => {
     const fileUploaderElement = screen.getByRole("button");
     expect(fileUploaderElement).toBeInTheDocument();
   });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<FileUploader />);
+  });
+
   // Add more tests as needed
 });

--- a/src/components/form-control/FormControl.test.tsx
+++ b/src/components/form-control/FormControl.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import FormControl from "./FormControl";
 import { INPUT_SIZE, Input } from "../input";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("FormControl", () => {
   it("renders without crashing", async () => {
@@ -13,6 +14,34 @@ describe("FormControl", () => {
 
     const formControlElement = screen.getByPlaceholderText(/Test FormControl/i);
     expect(formControlElement).toBeInTheDocument();
+  });
+
+  it("handles custom size", async () => {
+    const { rerender } = render(
+      <FormControl size={INPUT_SIZE.medium}>
+        <Input placeholder="Test FormControl" />
+      </FormControl>
+    );
+
+    let formControlElement = screen.getByPlaceholderText(/Test FormControl/i);
+    expect(formControlElement).toBeInTheDocument();
+
+    rerender(
+      <FormControl size={INPUT_SIZE.small}>
+        <Input placeholder="Test FormControl" />
+      </FormControl>
+    );
+
+    formControlElement = screen.getByPlaceholderText(/Test FormControl/i);
+    expect(formControlElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <FormControl size={INPUT_SIZE.medium}>
+        <Input placeholder="Test FormControl" />
+      </FormControl>
+    );
   });
 
   // Add more tests as needed

--- a/src/components/input/Input.test.tsx
+++ b/src/components/input/Input.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import Input from "./Input";
 import { INPUT_KIND, INPUT_SIZE } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Input", () => {
   it("renders without crashing", () => {
@@ -20,6 +21,10 @@ describe("Input", () => {
     userEvent.type(inputElement, "New Value");
 
     await waitFor(() => expect(handleChange).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Input size={INPUT_SIZE.medium} kind={INPUT_KIND.primary}></Input>);
   });
 
   // Add more tests as needed

--- a/src/components/list/List.test.tsx
+++ b/src/components/list/List.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import ListItem from "./ListItem";
 import ListItemLabel from "./ListItemLabel";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("List", () => {
   it("renders without crashing", () => {
@@ -24,6 +25,25 @@ describe("List", () => {
 
     const listElement = screen.getByRole("list");
     expect(listElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <ul>
+        <ListItem>
+          <ListItemLabel>Label One</ListItemLabel>
+        </ListItem>
+        <ListItem>
+          <ListItemLabel>Label Two</ListItemLabel>
+        </ListItem>
+        <ListItem>
+          <ListItemLabel description="description">Label Three</ListItemLabel>
+        </ListItem>
+        <ListItem>
+          <ListItemLabel description="description">Label Four</ListItemLabel>
+        </ListItem>
+      </ul>
+    );
   });
 
   // Add more tests as needed

--- a/src/components/menu/Menu.test.tsx
+++ b/src/components/menu/Menu.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import Menu from "./Menu";
 import { MENU_SIZE } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 const items = [{ label: "Item One" }, { label: "Item Two" }, { label: "Item Three" }, { label: "Item Four" }];
 
@@ -11,6 +12,22 @@ describe("Menu", () => {
 
     const menuElement = screen.getByText("Item One");
     expect(menuElement).toBeInTheDocument();
+  });
+
+  it("handles size prop", () => {
+    const { rerender } = render(<Menu size={MENU_SIZE.medium} items={items} />);
+
+    let menuElement = screen.getByText("Item One");
+    expect(menuElement).toBeInTheDocument();
+
+    rerender(<Menu size={MENU_SIZE.large} items={items} />);
+
+    menuElement = screen.getByText("Item One");
+    expect(menuElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Menu size={MENU_SIZE.medium} items={items} />);
   });
 
   // Add more tests as needed

--- a/src/components/modal/Modal.test.tsx
+++ b/src/components/modal/Modal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import Modal from "./Modal";
 import { ROLE } from "baseui/modal";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Modal", () => {
   it("renders without crashing", () => {
@@ -28,6 +29,14 @@ describe("Modal", () => {
     userEvent.click(closeButton);
 
     await waitFor(() => expect(handleClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <Modal isOpen={true} onClose={() => {}} role={ROLE.dialog}>
+        Test Modal
+      </Modal>
+    );
   });
 
   // Add more tests as needed

--- a/src/components/navigation-bar/NavigationBar.test.tsx
+++ b/src/components/navigation-bar/NavigationBar.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import NavigationBar from "./NavigationBar";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 export const items = [
   {
@@ -40,6 +41,17 @@ describe("NavigationBar", () => {
 
     const navigationBarElement = screen.getByRole("banner");
     expect(navigationBarElement).toBeInTheDocument();
+  });
+
+  it("handles custom brand", () => {
+    render(<NavigationBar brand={<div>Brand</div>} items={items} />);
+
+    const brandElement = screen.getByText("Brand");
+    expect(brandElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<NavigationBar brand={<div>Brand</div>} items={items} />);
   });
 
   // Add more tests as needed

--- a/src/components/notification/Notification.test.tsx
+++ b/src/components/notification/Notification.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import Notification from "./Notification";
 import { NOTIFICATION_KIND } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Notification", () => {
   it("renders without crashing", () => {
@@ -21,6 +22,10 @@ describe("Notification", () => {
 
     notificationElement = screen.getByText(/Test Notification/i);
     expect(notificationElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Notification kind={NOTIFICATION_KIND.info}>Test Notification</Notification>);
   });
 
   // Add more tests as needed

--- a/src/components/progress-bar/ProgressBar.test.tsx
+++ b/src/components/progress-bar/ProgressBar.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import ProgressBar from "./ProgressBar";
 import { PROGRESS_BAR_SIZE } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("ProgressBar", () => {
   it("renders without crashing", () => {
@@ -23,6 +24,12 @@ describe("ProgressBar", () => {
 
     progressBarElement = screen.getByRole("progressbar");
     expect(progressBarElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <ProgressBar infinite minValue={0} maxValue={100} value={50} size={PROGRESS_BAR_SIZE.medium} />
+    );
   });
 
   // Add more tests as needed

--- a/src/components/radio/Radio.test.tsx
+++ b/src/components/radio/Radio.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import Radio from "./Radio";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Radio", () => {
   it("renders without crashing", () => {
@@ -18,6 +19,10 @@ describe("Radio", () => {
     );
 
     expect(screen.getByRole("radio")).toBeChecked();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Radio value="test">Test Radio</Radio>);
   });
 
   // Add more tests as needed

--- a/src/components/select/Select.test.tsx
+++ b/src/components/select/Select.test.tsx
@@ -1,6 +1,8 @@
 import { screen } from "@testing-library/react";
 import Select from "./Select";
 import { render } from "../../test-utils/render";
+import { SELECT_SIZE } from "./types";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Select", () => {
   it("renders without crashing", () => {
@@ -8,6 +10,17 @@ describe("Select", () => {
 
     const comboboxes = screen.getAllByRole("combobox");
     expect(comboboxes.length).not.toBe(0);
+  });
+
+  it("handles custom size", () => {
+    render(<Select size={SELECT_SIZE.small} options={[{ id: "1", label: "Option 1" }]} />);
+
+    const comboboxes = screen.getAllByRole("combobox");
+    expect(comboboxes.length).not.toBe(0);
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Select startOpen options={[{ id: "1", label: "Option 1" }]} />);
   });
 
   // Add more tests as needed

--- a/src/components/skeleton/Skeleton.test.tsx
+++ b/src/components/skeleton/Skeleton.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import Skeleton from "./Skeleton";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Skeleton", () => {
   it("renders without crashing", () => {
@@ -8,6 +9,22 @@ describe("Skeleton", () => {
 
     const skeletonElement = screen.getByRole("progressbar");
     expect(skeletonElement).toBeInTheDocument();
+  });
+
+  it("handles custom animation", () => {
+    const { rerender } = render(<Skeleton animation={true} />);
+
+    let skeletonElement = screen.getByRole("progressbar");
+    expect(skeletonElement).toBeInTheDocument();
+
+    rerender(<Skeleton animation={false} />);
+
+    skeletonElement = screen.getByRole("progressbar");
+    expect(skeletonElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Skeleton animation={true} />);
   });
 
   // Add more tests as needed

--- a/src/components/spinner/Spinner.test.tsx
+++ b/src/components/spinner/Spinner.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import Spinner from "./Spinner";
 import { SPINNER_SIZE } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Spinner", () => {
   it("renders without crashing", () => {
@@ -21,6 +22,10 @@ describe("Spinner", () => {
 
     spinnerElement = screen.getByRole("status");
     expect(spinnerElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Spinner size={SPINNER_SIZE.medium} animation={true} />);
   });
 
   // Add more tests as needed

--- a/src/components/table/Table.test.tsx
+++ b/src/components/table/Table.test.tsx
@@ -2,13 +2,14 @@ import { screen, waitFor } from "@testing-library/react";
 import Table from "./Table";
 import { TABLE_DIVIDER, TABLE_SIZE } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
-export const data = [
+const data = [
   ["Sarah Brown", 31, "100 Broadway st. New York City, New York"],
   ["Jane Smith", 32, "100 Market st. San Francisco, California"],
   ["Joe Black", 33, "100 Macquarie st. Sydney, Australia"],
 ];
-export const columns = ["Name", "Age", "Address"];
+const columns = ["Name", "Age", "Address"];
 
 describe("Table", () => {
   it("renders without crashing", () => {
@@ -32,6 +33,12 @@ describe("Table", () => {
     await waitFor(() => {
       expect(tableElement).toBeInTheDocument();
     });
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <Table divider={TABLE_DIVIDER.horizontal} size={TABLE_SIZE.default} data={data} columns={columns}></Table>
+    );
   });
 
   // Add more tests as needed

--- a/src/components/tabs/Tabs.test.tsx
+++ b/src/components/tabs/Tabs.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import Tab from "./Tab";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Tab", () => {
   it("renders without crashing", () => {
@@ -21,6 +22,10 @@ describe("Tab", () => {
     const endEnhancerElement = screen.getByText(/End/i);
     expect(startEnhancerElement).toBeInTheDocument();
     expect(endEnhancerElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Tab>Test Tab</Tab>);
   });
 
   // Add more tests as needed

--- a/src/components/tag/Tag.test.tsx
+++ b/src/components/tag/Tag.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import Tag from "./Tag";
 import { TAG_KIND, TAG_SIZE } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Tag", () => {
   it("renders without crashing", () => {
@@ -35,6 +36,14 @@ describe("Tag", () => {
     await waitFor(() => {
       expect(tagElement).toBeInTheDocument();
     });
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <Tag kind={TAG_KIND.gray} size={TAG_SIZE.s}>
+        Test Tag
+      </Tag>
+    );
   });
 
   // Add more tests as needed

--- a/src/components/textarea/Textarea.test.tsx
+++ b/src/components/textarea/Textarea.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import Textarea from "./Textarea";
 import { TEXTAREA_KIND } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Textarea", () => {
   it("renders without crashing", () => {
@@ -22,6 +23,10 @@ describe("Textarea", () => {
     await waitFor(() => {
       expect(handleChange).toHaveBeenCalledTimes(13); // "Hello, World!" is 13 characters long
     });
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(<Textarea kind={TEXTAREA_KIND.primary} />);
   });
 
   // Add more tests as needed

--- a/src/components/toggle/Toggle.test.tsx
+++ b/src/components/toggle/Toggle.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Toggle, { LABEL_PLACEMENT } from "./Toggle";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Toggle", () => {
   it("renders without crashing", async () => {
@@ -31,6 +32,14 @@ describe("Toggle", () => {
     await waitFor(() => {
       expect(handleChange).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <Toggle labelPlacement={LABEL_PLACEMENT.right} checked={false} onChange={() => {}}>
+        Test Toggle
+      </Toggle>
+    );
   });
 
   // Add more tests as needed

--- a/src/components/toggleGroup/ToggleGroup.test.tsx
+++ b/src/components/toggleGroup/ToggleGroup.test.tsx
@@ -3,13 +3,15 @@ import userEvent from "@testing-library/user-event";
 import ToggleGroup from "./ToggleGroup";
 import { BUTTON_SIZE } from "../button";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
+
+const options = [
+  { key: "1", label: "Option 1" },
+  { key: "2", label: "Option 2" },
+];
 
 describe("ToggleGroupInner", () => {
   it("renders without crashing", () => {
-    const options = [
-      { key: "1", label: "Option 1" },
-      { key: "2", label: "Option 2" },
-    ];
     render(<ToggleGroup options={options} value={["1"]} onChange={() => {}} size={BUTTON_SIZE.compact} />);
 
     options.forEach((option) => {
@@ -20,10 +22,6 @@ describe("ToggleGroupInner", () => {
 
   it("handles toggle events", async () => {
     const handleChange = jest.fn();
-    const options = [
-      { key: "1", label: "Option 1" },
-      { key: "2", label: "Option 2" },
-    ];
     render(<ToggleGroup options={options} value={["1"]} onChange={handleChange} size={BUTTON_SIZE.compact} />);
 
     const optionElement = screen.getByText(/Option 1/i);
@@ -32,6 +30,12 @@ describe("ToggleGroupInner", () => {
     await waitFor(() => {
       expect(handleChange).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <ToggleGroup options={options} value={["1"]} onChange={() => {}} size={BUTTON_SIZE.compact} />
+    );
   });
 
   // Add more tests as needed

--- a/src/components/tooltip/Tooltip.test.tsx
+++ b/src/components/tooltip/Tooltip.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import Tooltip from "./Tooltip";
 import { TOOLTIP_KIND } from "./types";
 import { render } from "../../test-utils/render";
+import { createComponentSSRTest } from "../../createComponentSSRTest";
 
 describe("Tooltip", () => {
   it("renders without crashing", () => {
@@ -16,6 +17,14 @@ describe("Tooltip", () => {
 
     const contentElement = screen.getByText(/Content/i);
     expect(contentElement).toBeInTheDocument();
+  });
+
+  it("renders ssr without crashing", () => {
+    createComponentSSRTest(
+      <Tooltip kind={TOOLTIP_KIND.DEFAULT} isOpen content="Content">
+        <div>Test Tooltip</div>
+      </Tooltip>
+    );
   });
 
   // Add more tests as needed

--- a/src/createComponentSSRTest.ts
+++ b/src/createComponentSSRTest.ts
@@ -1,0 +1,23 @@
+import { ReactElement } from "react";
+import { renderToString } from "react-dom/server";
+
+// Ensures that browser-specific code does not run during SSR
+// To make test pass wrap browser specific code in useEffect
+export const createComponentSSRTest = (ui: ReactElement) => {
+  const windowSpy = jest.spyOn(global, "window", "get");
+  const documentSpy = jest.spyOn(global, "document", "get");
+  const locationSpy = jest.spyOn(global, "location", "get");
+  const navigatorSpy = jest.spyOn(global, "navigator", "get");
+
+  renderToString(ui);
+
+  expect(windowSpy).not.toHaveBeenCalled();
+  expect(documentSpy).not.toHaveBeenCalled();
+  expect(locationSpy).not.toHaveBeenCalled();
+  expect(navigatorSpy).not.toHaveBeenCalled();
+
+  windowSpy.mockRestore();
+  documentSpy.mockRestore();
+  locationSpy.mockRestore();
+  navigatorSpy.mockRestore();
+};

--- a/src/shared/hooks/useOnWindowResize.ts
+++ b/src/shared/hooks/useOnWindowResize.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { isBrowser } from "../utils/isBrowser";
 
 export function useOnWindowResize(callback: () => void) {
   const _useRef = useRef(callback),
@@ -7,10 +6,6 @@ export function useOnWindowResize(callback: () => void) {
 
   useEffect(function () {
     currentCallback();
-
-    if (!isBrowser()) {
-      return;
-    }
 
     window.addEventListener("resize", currentCallback);
     return function () {

--- a/src/shared/utils/isBrowser.ts
+++ b/src/shared/utils/isBrowser.ts
@@ -1,3 +1,0 @@
-export function isBrowser() {
-  return typeof window !== "undefined";
-}


### PR DESCRIPTION
This diff adds ssr rendering tests for all components except Typography (because it is just reexport from basui).
These tests are not complete ssr tests, because they don't check if components look the same after hydration (making them interactive). This is an issue with components architecture and we have nothing to do with it on the current step.

Simple workaround to avoid hydration errors is using `"use client";` directive in nextjs 13 and higher.

So, these tests just check that browser api is not used directly in the components (which causes error during ssr), but only inside uesEffect or useLayoutEffect.