### PR TITLE
Replace PRIMITIVE_COLORS with COLORS

### DIFF
--- a/.storybook/theme.ts
+++ b/.storybook/theme.ts
@@ -1,20 +1,20 @@
 import { create } from "@storybook/theming/create";
-import { PRIMITIVE_COLORS } from "../src/shared/theme";
+import { COLORS } from "../src/shared/theme";
 
 export default create({
   base: "dark",
-  colorSecondary: PRIMITIVE_COLORS.gray500,
-  appBg: PRIMITIVE_COLORS.gray900,
-  appContentBg: PRIMITIVE_COLORS.black,
-  appBorderColor: PRIMITIVE_COLORS.gray700,
+  colorSecondary: COLORS.gray500,
+  appBg: COLORS.gray900,
+  appContentBg: COLORS.black,
+  appBorderColor: COLORS.gray700,
   appBorderRadius: 4,
-  textColor: PRIMITIVE_COLORS.gray50,
-  textMutedColor: PRIMITIVE_COLORS.gray300,
-  barTextColor: PRIMITIVE_COLORS.gray200,
-  barSelectedColor: PRIMITIVE_COLORS.gray50,
-  barBg: PRIMITIVE_COLORS.gray900,
-  inputBg: PRIMITIVE_COLORS.gray700,
-  inputTextColor: PRIMITIVE_COLORS.gray50,
+  textColor: COLORS.gray50,
+  textMutedColor: COLORS.gray300,
+  barTextColor: COLORS.gray200,
+  barSelectedColor: COLORS.gray50,
+  barBg: COLORS.gray900,
+  inputBg: COLORS.gray700,
+  inputTextColor: COLORS.gray50,
   inputBorderRadius: 0,
   brandTitle: "=nil; Foundation UI kit storybook",
   brandUrl: "https://nil.foundation",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,7 @@
   "packages": {
     "": {
       "name": "@nilfoundation/ui-kit",
-<<<<<<< HEAD
-      "version": "2.5.0",
-=======
-      "version": "2.4.6",
->>>>>>> master
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "copy-to-clipboard": "^3.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nilfoundation/ui-kit",
-  "version": "2.4.5",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nilfoundation/ui-kit",
-      "version": "2.4.5",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "copy-to-clipboard": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nilfoundation/ui-kit",
-  "version": "2.4.5",
+  "version": "2.5.0",
   "description": "=Nil; Foundation user interface kit",
   "keywords": [
     "ui-kit",

--- a/src/components/accordion/ui/PanelTitle.tsx
+++ b/src/components/accordion/ui/PanelTitle.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactElement, ReactNode } from "react";
 import { useStyletron } from "baseui";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 import { ParagraphSmall } from "baseui/typography";
 
 type PanelTitle = {
@@ -31,13 +31,13 @@ const PanelTitle: FC<PanelTitle> = ({ title, description, icon }) => {
       {icon &&
         React.cloneElement(icon as ReactElement, {
           size: "20px",
-          color: PRIMITIVE_COLORS.white,
+          color: COLORS.white,
           className: css(iconStyles),
         })}
       <div>
         {title}
         {description && (
-          <ParagraphSmall color={PRIMITIVE_COLORS.white} className={css(descriptionStyles)}>
+          <ParagraphSmall color={COLORS.white} className={css(descriptionStyles)}>
             {description}
           </ParagraphSmall>
         )}

--- a/src/components/badge/styles.ts
+++ b/src/components/badge/styles.ts
@@ -1,7 +1,7 @@
 import { withoutBorderStyles } from "../../shared/styles/borderStyles";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { BADGE_COLOR } from "./types";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 export const badgeBaseStyles = {
   ...withoutBorderStyles,
@@ -12,38 +12,38 @@ export const badgeBaseStyles = {
 
 export const badgeColorModifiedStyles = {
   [BADGE_COLOR.accent]: {
-    backgroundColor: PRIMITIVE_COLORS.white,
-    color: PRIMITIVE_COLORS.black,
+    backgroundColor: COLORS.white,
+    color: COLORS.black,
   },
   [BADGE_COLOR.positive]: {
-    backgroundColor: PRIMITIVE_COLORS.green500,
-    color: PRIMITIVE_COLORS.white,
+    backgroundColor: COLORS.green500,
+    color: COLORS.white,
   },
   [BADGE_COLOR.warning]: {
-    backgroundColor: PRIMITIVE_COLORS.yellow500,
-    color: PRIMITIVE_COLORS.black,
+    backgroundColor: COLORS.yellow500,
+    color: COLORS.black,
   },
   [BADGE_COLOR.negative]: {
-    backgroundColor: PRIMITIVE_COLORS.red500,
-    color: PRIMITIVE_COLORS.white,
+    backgroundColor: COLORS.red500,
+    color: COLORS.white,
   },
 };
 
 export const badgeLowStyles = {
   [BADGE_COLOR.accent]: {
-    backgroundColor: PRIMITIVE_COLORS.gray700,
-    color: PRIMITIVE_COLORS.gray200,
+    backgroundColor: COLORS.gray700,
+    color: COLORS.gray200,
   },
   [BADGE_COLOR.positive]: {
-    backgroundColor: PRIMITIVE_COLORS.green700,
-    color: PRIMITIVE_COLORS.green300,
+    backgroundColor: COLORS.green700,
+    color: COLORS.green300,
   },
   [BADGE_COLOR.warning]: {
-    backgroundColor: PRIMITIVE_COLORS.yellow700,
-    color: PRIMITIVE_COLORS.yellow300,
+    backgroundColor: COLORS.yellow700,
+    color: COLORS.yellow300,
   },
   [BADGE_COLOR.negative]: {
-    backgroundColor: PRIMITIVE_COLORS.red700,
-    color: PRIMITIVE_COLORS.red300,
+    backgroundColor: COLORS.red700,
+    color: COLORS.red300,
   },
 };

--- a/src/components/breadcrumbs/BreadcrumbsItem.tsx
+++ b/src/components/breadcrumbs/BreadcrumbsItem.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode } from "react";
 import { Link as BaseLink } from "baseui/link/styled-components";
 import { withStyle } from "baseui";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 export type BreadcrumbsItemProps = {
   href?: string;
@@ -12,19 +12,19 @@ export type BreadcrumbsItemProps = {
 
 const getLinkColor = (isActive?: boolean, isDisabled?: boolean): string => {
   if (isDisabled) {
-    return PRIMITIVE_COLORS.gray500;
+    return COLORS.gray500;
   }
   if (isActive) {
-    return PRIMITIVE_COLORS.gray300;
+    return COLORS.gray300;
   }
-  return PRIMITIVE_COLORS.white;
+  return COLORS.white;
 };
 
 const getLinkHoverColor = (isActive?: boolean, isDisabled?: boolean): string => {
   if (isDisabled || isActive) {
     return getLinkColor(isActive, isDisabled);
   }
-  return PRIMITIVE_COLORS.gray200;
+  return COLORS.gray200;
 };
 
 const BreadcrumbsItem: FC<BreadcrumbsItemProps> = ({ isActive, disabled, href, children }) => {
@@ -38,7 +38,7 @@ const BreadcrumbsItem: FC<BreadcrumbsItemProps> = ({ isActive, disabled, href, c
     },
 
     ":focus": {
-      color: `${PRIMITIVE_COLORS.gray300} !important`,
+      color: `${COLORS.gray300} !important`,
     },
   });
 

--- a/src/components/breadcrumbs/ui/BreadcrumbsSeparator.tsx
+++ b/src/components/breadcrumbs/ui/BreadcrumbsSeparator.tsx
@@ -1,6 +1,6 @@
 import { FC, memo } from "react";
 import { useStyletron } from "baseui";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 
 const containerStyles = {
   display: "inline-flex",
@@ -15,7 +15,7 @@ const containerStyles = {
 const squareStyles = {
   width: "5px",
   height: "5px",
-  backgroundColor: PRIMITIVE_COLORS.white,
+  backgroundColor: COLORS.white,
 };
 
 const BreadcrumbsSeparator: FC = () => {

--- a/src/components/button/overrides.tsx
+++ b/src/components/button/overrides.tsx
@@ -9,7 +9,7 @@ import {
   checkedToggleButtonModifiedStyles,
   spinnerModifiedStyles,
 } from "./style";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 const spinnerSize = {
   [BUTTON_SIZE.mini]: SPINNER_SIZE.xSmall,
@@ -20,20 +20,20 @@ const spinnerSize = {
 
 const getSpinnerColor = (kind: BUTTON_KIND, disabled: boolean) => {
   if (disabled) {
-    return PRIMITIVE_COLORS.gray500;
+    return COLORS.gray500;
   }
 
   switch (kind) {
     case BUTTON_KIND.primary:
-      return PRIMITIVE_COLORS.gray900;
+      return COLORS.gray900;
     case BUTTON_KIND.secondary:
     case BUTTON_KIND.tertiary:
     case BUTTON_KIND.text:
     case BUTTON_KIND.toggle:
     case BUTTON_KIND.danger:
-      return PRIMITIVE_COLORS.gray50;
+      return COLORS.gray50;
     default:
-      return PRIMITIVE_COLORS.black;
+      return COLORS.black;
   }
 };
 

--- a/src/components/button/style.ts
+++ b/src/components/button/style.ts
@@ -1,4 +1,4 @@
-import { PRIMITIVE_COLORS, SPACE } from "../../shared";
+import { COLORS, SPACE } from "../../shared";
 import { BUTTON_KIND, BUTTON_SIZE } from "./types";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { boxShadowFocusStyles } from "../../shared/styles/boxShadowSharedStyles";
@@ -37,123 +37,123 @@ export const buttonModifiedStyles = {
 
 export const buttonKindModifiedStyles = {
   [BUTTON_KIND.primary]: {
-    backgroundColor: PRIMITIVE_COLORS.gray50,
-    color: PRIMITIVE_COLORS.gray900,
+    backgroundColor: COLORS.gray50,
+    color: COLORS.gray900,
 
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray200,
+      backgroundColor: COLORS.gray200,
     },
 
     ":active:not(:disabled)": {
-      backgroundColor: PRIMITIVE_COLORS.gray300,
+      backgroundColor: COLORS.gray300,
     },
 
     ":disabled": {
-      backgroundColor: PRIMITIVE_COLORS.gray800,
-      color: PRIMITIVE_COLORS.gray500,
+      backgroundColor: COLORS.gray800,
+      color: COLORS.gray500,
     },
   },
   [BUTTON_KIND.secondary]: {
-    backgroundColor: PRIMITIVE_COLORS.gray800,
-    color: PRIMITIVE_COLORS.gray200,
+    backgroundColor: COLORS.gray800,
+    color: COLORS.gray200,
 
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray700,
-      color: PRIMITIVE_COLORS.gray50,
+      backgroundColor: COLORS.gray700,
+      color: COLORS.gray50,
     },
 
     ":active:not(:disabled)": {
-      backgroundColor: PRIMITIVE_COLORS.gray600,
-      color: PRIMITIVE_COLORS.gray50,
+      backgroundColor: COLORS.gray600,
+      color: COLORS.gray50,
     },
 
     ":disabled": {
-      color: PRIMITIVE_COLORS.gray500,
-      backgroundColor: PRIMITIVE_COLORS.gray800,
+      color: COLORS.gray500,
+      backgroundColor: COLORS.gray800,
     },
   },
   [BUTTON_KIND.tertiary]: {
     backgroundColor: "transparent",
 
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray800,
-      color: PRIMITIVE_COLORS.gray50,
+      backgroundColor: COLORS.gray800,
+      color: COLORS.gray50,
     },
 
     ":active:not(:disabled)": {
-      backgroundColor: PRIMITIVE_COLORS.gray700,
-      color: PRIMITIVE_COLORS.gray50,
+      backgroundColor: COLORS.gray700,
+      color: COLORS.gray50,
     },
 
     ":disabled": {
-      color: PRIMITIVE_COLORS.gray500,
+      color: COLORS.gray500,
     },
   },
   [BUTTON_KIND.danger]: {
-    backgroundColor: PRIMITIVE_COLORS.red500,
-    color: PRIMITIVE_COLORS.gray50,
+    backgroundColor: COLORS.red500,
+    color: COLORS.gray50,
 
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.red600,
+      backgroundColor: COLORS.red600,
     },
 
     ":active:not(:disabled)": {
-      backgroundColor: PRIMITIVE_COLORS.red800,
+      backgroundColor: COLORS.red800,
     },
 
     ":disabled": {
-      backgroundColor: PRIMITIVE_COLORS.red800,
-      color: PRIMITIVE_COLORS.gray500,
+      backgroundColor: COLORS.red800,
+      color: COLORS.gray500,
     },
   },
   [BUTTON_KIND.toggle]: {
-    backgroundColor: PRIMITIVE_COLORS.gray800,
-    color: PRIMITIVE_COLORS.gray200,
+    backgroundColor: COLORS.gray800,
+    color: COLORS.gray200,
 
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray700,
-      color: PRIMITIVE_COLORS.gray50,
+      backgroundColor: COLORS.gray700,
+      color: COLORS.gray50,
     },
 
     ":active:not(:disabled)": {
-      backgroundColor: PRIMITIVE_COLORS.gray600,
-      color: PRIMITIVE_COLORS.gray50,
+      backgroundColor: COLORS.gray600,
+      color: COLORS.gray50,
     },
 
     ":disabled": {
-      color: PRIMITIVE_COLORS.gray500,
-      backgroundColor: PRIMITIVE_COLORS.gray800,
+      color: COLORS.gray500,
+      backgroundColor: COLORS.gray800,
     },
   },
   [BUTTON_KIND.text]: {
     backgroundColor: "transparent",
-    color: PRIMITIVE_COLORS.gray200,
+    color: COLORS.gray200,
     textDecoration: "underline",
 
     ":hover": {
       backgroundColor: "transparent",
-      color: PRIMITIVE_COLORS.gray50,
+      color: COLORS.gray50,
     },
 
     ":active:not(:disabled)": {
       backgroundColor: "transparent",
-      color: PRIMITIVE_COLORS.gray50,
+      color: COLORS.gray50,
     },
 
     ":disabled": {
       backgroundColor: "transparent",
-      color: PRIMITIVE_COLORS.gray500,
+      color: COLORS.gray500,
     },
   },
 };
 
 export const buttonFocusedModifiedStyles = {
   [BUTTON_KIND.primary]: {
-    backgroundColor: PRIMITIVE_COLORS.gray50,
+    backgroundColor: COLORS.gray50,
     ...boxShadowFocusStyles,
   },
   [BUTTON_KIND.secondary]: {
-    color: PRIMITIVE_COLORS.gray50,
+    color: COLORS.gray50,
     ...boxShadowFocusStyles,
   },
   [BUTTON_KIND.tertiary]: {
@@ -163,11 +163,11 @@ export const buttonFocusedModifiedStyles = {
     ...boxShadowFocusStyles,
   },
   [BUTTON_KIND.toggle]: {
-    color: PRIMITIVE_COLORS.gray50,
+    color: COLORS.gray50,
     ...boxShadowFocusStyles,
   },
   [BUTTON_KIND.text]: {
-    color: PRIMITIVE_COLORS.gray50,
+    color: COLORS.gray50,
     ...boxShadowFocusStyles,
   },
 };
@@ -175,37 +175,37 @@ export const buttonFocusedModifiedStyles = {
 export const buttonDisabledModifiedStyles = {
   [BUTTON_KIND.primary]: {
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray800,
-      color: PRIMITIVE_COLORS.gray500,
+      backgroundColor: COLORS.gray800,
+      color: COLORS.gray500,
     },
   },
   [BUTTON_KIND.secondary]: {
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray800,
-      color: PRIMITIVE_COLORS.gray500,
+      backgroundColor: COLORS.gray800,
+      color: COLORS.gray500,
     },
   },
   [BUTTON_KIND.tertiary]: {
     ":hover": {
       backgroundColor: "transparent",
-      color: PRIMITIVE_COLORS.gray500,
+      color: COLORS.gray500,
     },
   },
   [BUTTON_KIND.danger]: {
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.red800,
-      color: PRIMITIVE_COLORS.gray500,
+      backgroundColor: COLORS.red800,
+      color: COLORS.gray500,
     },
   },
   [BUTTON_KIND.toggle]: {
     ":hover": {
-      color: PRIMITIVE_COLORS.gray500,
-      backgroundColor: PRIMITIVE_COLORS.gray800,
+      color: COLORS.gray500,
+      backgroundColor: COLORS.gray800,
     },
   },
   [BUTTON_KIND.text]: {
     ":hover": {
-      color: PRIMITIVE_COLORS.gray500,
+      color: COLORS.gray500,
       backgroundColor: "transparent",
     },
   },
@@ -231,19 +231,19 @@ export const spinnerModifiedStyles = {
 };
 
 export const checkedToggleButtonModifiedStyles = {
-  backgroundColor: PRIMITIVE_COLORS.gray50,
-  color: PRIMITIVE_COLORS.gray900,
+  backgroundColor: COLORS.gray50,
+  color: COLORS.gray900,
 
   ":hover": {
-    backgroundColor: PRIMITIVE_COLORS.gray200,
+    backgroundColor: COLORS.gray200,
   },
 
   ":active:not(:disabled)": {
-    backgroundColor: PRIMITIVE_COLORS.gray300,
+    backgroundColor: COLORS.gray300,
   },
 
   ":disabled": {
-    backgroundColor: PRIMITIVE_COLORS.gray800,
-    color: PRIMITIVE_COLORS.gray500,
+    backgroundColor: COLORS.gray800,
+    color: COLORS.gray500,
   },
 };

--- a/src/components/card/overrides.tsx
+++ b/src/components/card/overrides.tsx
@@ -1,6 +1,6 @@
 import { CardOverrides } from "baseui/card";
 import { withoutBorderStyles } from "../../shared/styles/borderStyles";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { withoutMarginStyles } from "../../shared/styles/withoutMarginStyles";
 import { expandProperty } from "inline-style-expand-shorthand";
 
@@ -18,8 +18,8 @@ export const getCardOverrides = (headline: boolean, border: boolean): CardOverri
         paddingBottom: "0px",
         boxSizing: "border-box",
         maxWidth: "328px",
-        backgroundColor: PRIMITIVE_COLORS.gray800,
-        border: border ? `1px solid ${PRIMITIVE_COLORS.gray700}` : `1px solid transparent`,
+        backgroundColor: COLORS.gray800,
+        border: border ? `1px solid ${COLORS.gray700}` : `1px solid transparent`,
       },
     },
     HeaderImage: {

--- a/src/components/card/styles.ts
+++ b/src/components/card/styles.ts
@@ -1,5 +1,5 @@
 import { StyleObject } from "styletron-react";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 export const styledWhiteHeadline: StyleObject = {
   position: "absolute",
@@ -7,5 +7,5 @@ export const styledWhiteHeadline: StyleObject = {
   left: 0,
   width: "100%",
   height: "8px",
-  background: PRIMITIVE_COLORS.white,
+  background: COLORS.white,
 };

--- a/src/components/chart/ChartWidget.tsx
+++ b/src/components/chart/ChartWidget.tsx
@@ -3,7 +3,7 @@ import { ChartWidgetProps } from "./types";
 import ChartWrapper from "./ChartWrapper";
 import { ChartOptions, DeepPartial } from "lightweight-charts";
 import { LineSeries } from "./series";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { styles } from "./styles";
 import { useStyletron } from "styletron-react";
 
@@ -22,7 +22,7 @@ const chartWidgetDefaultOptions: DeepPartial<ChartOptions> = {
 };
 
 const ChartWidgetRender: ForwardRefRenderFunction<HTMLDivElement, ChartWidgetProps> = (
-  { data, color = PRIMITIVE_COLORS.blue300, className, ...rest },
+  { data, color = COLORS.blue300, className, ...rest },
   ref
 ) => {
   const [css] = useStyletron();

--- a/src/components/chart/chartDefaultOptions.ts
+++ b/src/components/chart/chartDefaultOptions.ts
@@ -1,6 +1,6 @@
 import { ColorType } from "lightweight-charts";
 import type { ChartOptions, DeepPartial } from "lightweight-charts";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { priceScaleDefaultOptions } from "./scales";
 import { timeScaleDefaultOptions } from "./scales/scalesDefaultOptions";
 
@@ -8,10 +8,10 @@ export const chartDefaultOptions: DeepPartial<ChartOptions> = {
   layout: {
     background: {
       type: ColorType.Solid,
-      color: PRIMITIVE_COLORS.gray900,
+      color: COLORS.gray900,
     },
     fontFamily: "Inter, sans-serif",
-    textColor: PRIMITIVE_COLORS.gray400,
+    textColor: COLORS.gray400,
   },
   grid: {
     vertLines: { visible: false },
@@ -19,14 +19,14 @@ export const chartDefaultOptions: DeepPartial<ChartOptions> = {
   },
   crosshair: {
     vertLine: {
-      color: PRIMITIVE_COLORS.gray50,
+      color: COLORS.gray50,
       width: 1,
       style: 0,
       visible: true,
       labelVisible: true,
     },
     horzLine: {
-      color: PRIMITIVE_COLORS.gray50,
+      color: COLORS.gray50,
       width: 1,
       style: 0,
       visible: true,

--- a/src/components/chart/series/seriesDefaultOptions.ts
+++ b/src/components/chart/series/seriesDefaultOptions.ts
@@ -6,39 +6,39 @@ import type {
   LineSeriesPartialOptions,
   SeriesType,
 } from "lightweight-charts";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 
 const seriesBaseDefaultOptions: DeepPartial<SeriesOptionsCommon> = {
-  priceLineColor: PRIMITIVE_COLORS.blue300,
+  priceLineColor: COLORS.blue300,
 };
 
 const seriesCandlestickDefaultOptions: CandlestickSeriesPartialOptions = {
   ...seriesBaseDefaultOptions,
-  upColor: PRIMITIVE_COLORS.green300,
-  downColor: PRIMITIVE_COLORS.red300,
+  upColor: COLORS.green300,
+  downColor: COLORS.red300,
   borderVisible: false,
   wickVisible: true,
-  borderColor: PRIMITIVE_COLORS.green300,
-  wickColor: PRIMITIVE_COLORS.green300,
-  borderUpColor: PRIMITIVE_COLORS.green300,
-  borderDownColor: PRIMITIVE_COLORS.red300,
-  wickUpColor: PRIMITIVE_COLORS.green300,
-  wickDownColor: PRIMITIVE_COLORS.red300,
+  borderColor: COLORS.green300,
+  wickColor: COLORS.green300,
+  borderUpColor: COLORS.green300,
+  borderDownColor: COLORS.red300,
+  wickUpColor: COLORS.green300,
+  wickDownColor: COLORS.red300,
 };
 
 const seriesLineDefaultOptions: LineSeriesPartialOptions = {
   ...seriesBaseDefaultOptions,
-  color: PRIMITIVE_COLORS.blue300,
+  color: COLORS.blue300,
   lineWidth: 2,
   crosshairMarkerVisible: false,
   crosshairMarkerRadius: 0,
-  crosshairMarkerBorderColor: PRIMITIVE_COLORS.blue300,
-  crosshairMarkerBackgroundColor: PRIMITIVE_COLORS.blue300,
+  crosshairMarkerBorderColor: COLORS.blue300,
+  crosshairMarkerBackgroundColor: COLORS.blue300,
 };
 
 const seriesHistogramDefaultOptions: HistogramSeriesPartialOptions = {
   ...seriesBaseDefaultOptions,
-  color: PRIMITIVE_COLORS.blue300,
+  color: COLORS.blue300,
   base: 0,
 };
 

--- a/src/components/chart/styles.ts
+++ b/src/components/chart/styles.ts
@@ -1,5 +1,5 @@
 import { StyleObject } from "styletron-standard";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 const containerStyles: StyleObject = {
   width: "100%",
@@ -19,7 +19,7 @@ const widgetShadowStyles: StyleObject = {
   left: 0,
   width: "24px",
   height: "100%",
-  background: `linear-gradient(90deg, ${PRIMITIVE_COLORS.gray900} 0%, rgba(33, 33, 33, 0) 100%)`,
+  background: `linear-gradient(90deg, ${COLORS.gray900} 0%, rgba(33, 33, 33, 0) 100%)`,
   zIndex: 2,
 };
 

--- a/src/components/checkbox/checkmarks.tsx
+++ b/src/components/checkbox/checkmarks.tsx
@@ -1,8 +1,8 @@
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { encodeInlineSvg } from "../../shared/utils/encodeInlineSvg";
 import { getCheckmarkSvg } from "../../shared/utils/getCheckmarkSvg";
 
-export const blackCheckmark = getCheckmarkSvg(PRIMITIVE_COLORS.gray900, 12);
+export const blackCheckmark = getCheckmarkSvg(COLORS.gray900, 12);
 
 export const blackIndeterminateCheckmark =
   "<svg width='8' height='3' viewBox='0 0 8 3' fill='none' xmlns='http://www.w3.org/2000/svg'><rect width='7.5' height='2.5' fill='#000000'/></svg>";

--- a/src/components/checkbox/styles.ts
+++ b/src/components/checkbox/styles.ts
@@ -1,4 +1,4 @@
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { withoutMarginStyles } from "../../shared/styles/withoutMarginStyles";
 import { withoutBorderStyles } from "../../shared/styles/borderStyles";
@@ -17,29 +17,29 @@ export const getCheckmarkBaseStyles = (isIndeterminate: boolean) => ({
 });
 
 export const checkmarkBaseModifiedStyles = {
-  backgroundColor: PRIMITIVE_COLORS.gray700,
+  backgroundColor: COLORS.gray700,
 
   ":hover": {
-    backgroundColor: PRIMITIVE_COLORS.gray600,
+    backgroundColor: COLORS.gray600,
   },
   ":active": {
-    backgroundColor: PRIMITIVE_COLORS.gray500,
+    backgroundColor: COLORS.gray500,
   },
 };
 
 export const checkmarkCheckedModifiedStyles = {
-  backgroundColor: PRIMITIVE_COLORS.gray200,
+  backgroundColor: COLORS.gray200,
 
   ":hover": {
-    backgroundColor: PRIMITIVE_COLORS.gray100,
+    backgroundColor: COLORS.gray100,
   },
   ":active": {
-    backgroundColor: PRIMITIVE_COLORS.gray50,
+    backgroundColor: COLORS.gray50,
   },
 };
 
 export const getCheckmarkDisabledModifiedStyles = (isChecked: boolean) => {
-  const backgroundColor = isChecked ? PRIMITIVE_COLORS.gray700 : PRIMITIVE_COLORS.gray800;
+  const backgroundColor = isChecked ? COLORS.gray700 : COLORS.gray800;
 
   return {
     backgroundColor,

--- a/src/components/codefield/codeMirrorTheme.ts
+++ b/src/components/codefield/codeMirrorTheme.ts
@@ -1,40 +1,40 @@
 import { createTheme } from "@uiw/codemirror-themes";
 import type { CreateThemeOptions } from "@uiw/codemirror-themes";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { tags as t } from "@lezer/highlight";
 
 const defaultSettings = {
   background: "transparent",
-  foreground: PRIMITIVE_COLORS.gray100,
-  lineHighlight: PRIMITIVE_COLORS.gray700,
-  selection: PRIMITIVE_COLORS.gray600,
-  selectionMatch: PRIMITIVE_COLORS.gray600,
+  foreground: COLORS.gray100,
+  lineHighlight: COLORS.gray700,
+  selection: COLORS.gray600,
+  selectionMatch: COLORS.gray600,
   fontFamily: "Roboto Mono, monospace",
-  caret: PRIMITIVE_COLORS.gray100,
+  caret: COLORS.gray100,
   gutterBackground: "transparent",
-  gutterForeground: PRIMITIVE_COLORS.gray300,
+  gutterForeground: COLORS.gray300,
 } satisfies CreateThemeOptions["settings"];
 
 const defaultStyles = [
-  { tag: t.keyword, color: PRIMITIVE_COLORS.purple300 },
-  { tag: [t.name, t.deleted, t.character, t.macroName], color: PRIMITIVE_COLORS.gray500 },
-  { tag: [t.propertyName], color: PRIMITIVE_COLORS.yellow300 },
-  { tag: [t.processingInstruction, t.string, t.inserted, t.special(t.string)], color: PRIMITIVE_COLORS.green300 },
-  { tag: [t.function(t.variableName), t.labelName], color: PRIMITIVE_COLORS.yellow300 },
-  { tag: [t.color, t.constant(t.name), t.standard(t.name)], color: PRIMITIVE_COLORS.green300 },
-  { tag: [t.definition(t.name), t.separator], color: PRIMITIVE_COLORS.gray500 },
-  { tag: [t.className], color: PRIMITIVE_COLORS.purple300 },
-  { tag: [t.number, t.changed, t.annotation, t.modifier, t.self, t.namespace], color: PRIMITIVE_COLORS.blue300 },
-  { tag: [t.typeName], color: PRIMITIVE_COLORS.green300 },
-  { tag: [t.operator, t.operatorKeyword], color: PRIMITIVE_COLORS.purple300 },
-  { tag: [t.url, t.escape, t.regexp, t.link], color: PRIMITIVE_COLORS.green300 },
-  { tag: [t.meta, t.comment], color: PRIMITIVE_COLORS.gray500 },
+  { tag: t.keyword, color: COLORS.purple300 },
+  { tag: [t.name, t.deleted, t.character, t.macroName], color: COLORS.gray500 },
+  { tag: [t.propertyName], color: COLORS.yellow300 },
+  { tag: [t.processingInstruction, t.string, t.inserted, t.special(t.string)], color: COLORS.green300 },
+  { tag: [t.function(t.variableName), t.labelName], color: COLORS.yellow300 },
+  { tag: [t.color, t.constant(t.name), t.standard(t.name)], color: COLORS.green300 },
+  { tag: [t.definition(t.name), t.separator], color: COLORS.gray500 },
+  { tag: [t.className], color: COLORS.purple300 },
+  { tag: [t.number, t.changed, t.annotation, t.modifier, t.self, t.namespace], color: COLORS.blue300 },
+  { tag: [t.typeName], color: COLORS.green300 },
+  { tag: [t.operator, t.operatorKeyword], color: COLORS.purple300 },
+  { tag: [t.url, t.escape, t.regexp, t.link], color: COLORS.green300 },
+  { tag: [t.meta, t.comment], color: COLORS.gray500 },
   { tag: t.strong, fontWeight: "bold" },
   { tag: t.emphasis, fontStyle: "italic" },
   { tag: t.link, textDecoration: "underline" },
-  { tag: t.heading, fontWeight: "bold", color: PRIMITIVE_COLORS.purple300 },
-  { tag: [t.atom, t.bool, t.special(t.variableName)], color: PRIMITIVE_COLORS.blue300 },
-  { tag: t.invalid, color: PRIMITIVE_COLORS.red300 },
+  { tag: t.heading, fontWeight: "bold", color: COLORS.purple300 },
+  { tag: [t.atom, t.bool, t.special(t.variableName)], color: COLORS.blue300 },
+  { tag: t.invalid, color: COLORS.red300 },
   { tag: t.strikethrough, textDecoration: "line-through" },
 ] satisfies CreateThemeOptions["styles"];
 

--- a/src/components/codefield/defaultStylesOverridesExtension.ts
+++ b/src/components/codefield/defaultStylesOverridesExtension.ts
@@ -1,5 +1,5 @@
 import { EditorView } from "@codemirror/view";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 export const createDefaultStylesOverridesExtension = (showLineNumbers: boolean) =>
   EditorView.theme({
@@ -25,6 +25,6 @@ export const createDefaultStylesOverridesExtension = (showLineNumbers: boolean) 
           }),
     },
     ".cm-activeLineGutter": {
-      color: PRIMITIVE_COLORS.gray200,
+      color: COLORS.gray200,
     },
   });

--- a/src/components/codefield/styles.ts
+++ b/src/components/codefield/styles.ts
@@ -1,11 +1,11 @@
 import { StyleObject } from "styletron-react";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 
 const containerStyles: StyleObject = {
   position: "relative",
   overflow: "hidden",
-  background: PRIMITIVE_COLORS.gray900,
+  background: COLORS.gray900,
   borderRadius: "4px",
   ...expandProperty("padding", "24px"),
   display: "flex",
@@ -15,7 +15,7 @@ const containerStyles: StyleObject = {
   gap: "16px",
   ...expandProperty("transition", "background 0.15s"),
   ":hover": {
-    background: PRIMITIVE_COLORS.gray800,
+    background: COLORS.gray800,
   },
 };
 

--- a/src/components/drawer/overrides.tsx
+++ b/src/components/drawer/overrides.tsx
@@ -1,12 +1,12 @@
 import { DrawerOverrides } from "baseui/drawer";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import DrawerClose from "./ui/DrawerClose";
 
 export const getDrawerOverrides = (): DrawerOverrides => {
   return {
     DrawerContainer: {
       style: () => ({
-        backgroundColor: PRIMITIVE_COLORS.gray800,
+        backgroundColor: COLORS.gray800,
       }),
     },
     Backdrop: {

--- a/src/components/drawer/ui/DrawerClose.tsx
+++ b/src/components/drawer/ui/DrawerClose.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { useStyletron } from "baseui";
 import { CloseIcon } from "../../icons";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 
 type DrawerCloseProps = {
   onBlur?: React.FocusEventHandler;
@@ -31,7 +31,7 @@ const DrawerClose: FC<DrawerCloseProps> = ({ onClick, onFocus, onBlur }) => {
   return (
     // @ts-ignore
     <button onClick={onClick} onFocus={onFocus} onBlur={onBlur} className={css(buttonStyles)}>
-      <CloseIcon size={24} color={PRIMITIVE_COLORS.white} />
+      <CloseIcon size={24} color={COLORS.white} />
     </button>
   );
 };

--- a/src/components/error-page/overrides.ts
+++ b/src/components/error-page/overrides.ts
@@ -1,5 +1,5 @@
 import { BlockOverrides } from "baseui/block";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { desktopMediaQuery, mobileMediaQuery } from "./styles";
 
@@ -8,7 +8,7 @@ export const getErrorCodeOverrides = (): BlockOverrides => ({
     style: {
       letterSpacing: "-0.08em",
       ...expandProperty("margin", "0"),
-      background: PRIMITIVE_COLORS.gray900,
+      background: COLORS.gray900,
       [desktopMediaQuery]: {
         height: "calc(100vh / 2.25)",
         lineHeight: "calc(100vh / 2.25)",

--- a/src/components/error-page/styles.ts
+++ b/src/components/error-page/styles.ts
@@ -1,4 +1,4 @@
-import { PRIMITIVE_COLORS, svgInlineDotsPattern } from "../../shared";
+import { COLORS, svgInlineDotsPattern } from "../../shared";
 import { StyleObject } from "styletron-standard";
 
 export const mobileScreenMaxWidth = 767;
@@ -8,7 +8,7 @@ export const mobileMediaQuery = `@media (max-width: ${mobileScreenMaxWidth}px)`;
 const containerStyles = {
   width: "100%",
   height: "100%",
-  color: PRIMITIVE_COLORS.white,
+  color: COLORS.white,
   flexGrow: "1",
   background: `url(${svgInlineDotsPattern}), repeat`,
   [desktopMediaQuery]: {

--- a/src/components/error-page/ui/Block.tsx
+++ b/src/components/error-page/ui/Block.tsx
@@ -1,8 +1,8 @@
 import { styled } from "styletron-react";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 
 const blockStyles = {
-  background: PRIMITIVE_COLORS.gray900,
+  background: COLORS.gray900,
   display: "flex",
   flexDirection: "column",
   flexGrow: "1",

--- a/src/components/error-page/ui/WhiteRect.tsx
+++ b/src/components/error-page/ui/WhiteRect.tsx
@@ -1,11 +1,11 @@
 import { styled } from "styletron-react";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 
 const whiteRectangleStyles = {
   width: "100%",
   height: "30px",
   flexShrink: 0,
-  background: PRIMITIVE_COLORS.white,
+  background: COLORS.white,
 } as const;
 
 const WhiteRect = styled("div", whiteRectangleStyles);

--- a/src/components/file-uploader/styles.ts
+++ b/src/components/file-uploader/styles.ts
@@ -1,5 +1,5 @@
 import { StyleObject } from "styletron-react";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { withoutBorderStyles } from "../../shared/styles/borderStyles";
 
@@ -13,9 +13,9 @@ export const getUploaderContainerStyles = (isDragActive?: boolean): StyleObject 
     width: "100%",
     minHeight: "136px",
     boxSizing: "border-box",
-    backgroundColor: PRIMITIVE_COLORS.gray800,
+    backgroundColor: COLORS.gray800,
     ...withoutBorderStyles,
-    ...expandProperty("border", `2px solid ${isDragActive ? PRIMITIVE_COLORS.white : PRIMITIVE_COLORS.gray700}`),
+    ...expandProperty("border", `2px solid ${isDragActive ? COLORS.white : COLORS.gray700}`),
     ...expandProperty("padding", `${isDragActive ? 0 : "32px 32px 22px 32px"}`),
   };
 };

--- a/src/components/form-control/overrides.tsx
+++ b/src/components/form-control/overrides.tsx
@@ -1,16 +1,16 @@
 import { INPUT_SIZE } from "../input";
 import { FormControlOverrides } from "baseui/form-control";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import FormControlLabel from "./ui/FormControlLabel";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { ParagraphXSmall } from "baseui/typography";
 
 const getCaptionColor = (isError: boolean): string => {
   if (isError) {
-    return PRIMITIVE_COLORS.red400;
+    return COLORS.red400;
   }
 
-  return PRIMITIVE_COLORS.gray300;
+  return COLORS.gray300;
 };
 
 export const getFormControlOverrides = (
@@ -31,7 +31,7 @@ export const getFormControlOverrides = (
         />
       ),
       style: {
-        color: PRIMITIVE_COLORS.gray50,
+        color: COLORS.gray50,
         ...expandProperty("margin", "4px 0"),
       },
     },

--- a/src/components/form-control/ui/FormControlLabel.tsx
+++ b/src/components/form-control/ui/FormControlLabel.tsx
@@ -1,7 +1,7 @@
 import { ComponentProps, FC, ReactNode } from "react";
 import { INPUT_SIZE } from "../../input";
 import { LabelMedium, LabelSmall } from "baseui/typography";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 import { useStyletron } from "baseui";
 import { StyleObject } from "styletron-react";
 
@@ -39,15 +39,15 @@ const FormControlLabel: FC<FormControlLabelProps> = ({
   const [css] = useStyletron();
   const LabelComponent = labelComponent[size];
 
-  const labelColor = isDisabled ? PRIMITIVE_COLORS.gray300 : PRIMITIVE_COLORS.white;
+  const labelColor = isDisabled ? COLORS.gray300 : COLORS.white;
 
   return (
     <div className={css(containerStyles)}>
       <LabelComponent color={labelColor} {...props}>
         {children}
       </LabelComponent>
-      {valueLabel && <LabelComponent color={PRIMITIVE_COLORS.gray300}>{valueLabel}</LabelComponent>}
-      {required && <LabelComponent color={PRIMITIVE_COLORS.red400}>*</LabelComponent>}
+      {valueLabel && <LabelComponent color={COLORS.gray300}>{valueLabel}</LabelComponent>}
+      {required && <LabelComponent color={COLORS.red400}>*</LabelComponent>}
     </div>
   );
 };

--- a/src/components/icons/CopyIcon.tsx
+++ b/src/components/icons/CopyIcon.tsx
@@ -2,7 +2,7 @@ import { FC, memo } from "react";
 import { IconProps } from "./types";
 import { getPreparedSvgProps } from "./utils";
 import { Svg } from "baseui/icon/styled-components";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 const CopyIcon: FC<IconProps> = ({ title, ...props }) => {
   const svgProps = getPreparedSvgProps(props);
@@ -13,13 +13,13 @@ const CopyIcon: FC<IconProps> = ({ title, ...props }) => {
         fillRule="evenodd"
         clipRule="evenodd"
         d="M12.375 5.625H2.25V15.75H12.375V5.625ZM1.125 4.5V16.875H13.5V4.5H1.125Z"
-        fill={PRIMITIVE_COLORS.gray50}
+        fill={COLORS.gray50}
       />
       <path
         fillRule="evenodd"
         clipRule="evenodd"
         d="M5.625 1.125H16.875V12.375H13.275V11.25H15.75V2.25H6.75V4.725H5.625V1.125Z"
-        fill={PRIMITIVE_COLORS.gray50}
+        fill={COLORS.gray50}
       />
     </Svg>
   );

--- a/src/components/list/overrides.tsx
+++ b/src/components/list/overrides.tsx
@@ -7,7 +7,7 @@ import {
   listItemContentDisabledStyles,
   listItemContentStyles,
 } from "./styles";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 export const getListItemOverrides = (isActive: boolean, isDisabled: boolean): ListOverrides => {
   return {
@@ -23,7 +23,7 @@ export const getListItemOverrides = (isActive: boolean, isDisabled: boolean): Li
     ArtworkContainer: {
       style: () => {
         return {
-          color: PRIMITIVE_COLORS.white,
+          color: COLORS.white,
           size: "40px",
         };
       },
@@ -43,7 +43,7 @@ export const getListItemLabelOverrides = (isDisabled: boolean): LabelOverrides =
     LabelDescription: {
       style: () => {
         return {
-          color: isDisabled ? PRIMITIVE_COLORS.gray600 : PRIMITIVE_COLORS.gray500,
+          color: isDisabled ? COLORS.gray600 : COLORS.gray500,
         };
       },
     },

--- a/src/components/list/styles.ts
+++ b/src/components/list/styles.ts
@@ -1,4 +1,4 @@
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 
 export const listItemContentStyles = {
@@ -6,36 +6,36 @@ export const listItemContentStyles = {
   ...expandProperty("borderBottom", "none"),
   marginLeft: "0",
   boxSizing: "border-box",
-  backgroundImage: `linear-gradient(to right, ${PRIMITIVE_COLORS.gray600} 36%, rgba(255,255,255,0) 0%)`,
+  backgroundImage: `linear-gradient(to right, ${COLORS.gray600} 36%, rgba(255,255,255,0) 0%)`,
   backgroundPosition: `bottom`,
   backgroundSize: `10px 4px`,
   backgroundRepeat: `repeat-x`,
-  color: PRIMITIVE_COLORS.gray500,
+  color: COLORS.gray500,
 
   ":hover": {
-    backgroundImage: `linear-gradient(to right, ${PRIMITIVE_COLORS.gray600} 100%, rgba(255,255,255,0) 0%)`,
-    color: PRIMITIVE_COLORS.gray300,
+    backgroundImage: `linear-gradient(to right, ${COLORS.gray600} 100%, rgba(255,255,255,0) 0%)`,
+    color: COLORS.gray300,
   },
 };
 
 export const listItemContentActiveStyles = {
-  backgroundImage: `linear-gradient(to right, ${PRIMITIVE_COLORS.white} 100%, rgba(255,255,255,0) 0%)`,
-  color: PRIMITIVE_COLORS.white,
+  backgroundImage: `linear-gradient(to right, ${COLORS.white} 100%, rgba(255,255,255,0) 0%)`,
+  color: COLORS.white,
 
   ":hover": {
-    backgroundImage: `linear-gradient(to right, ${PRIMITIVE_COLORS.white} 100%, rgba(255,255,255,0) 0%)`,
-    color: PRIMITIVE_COLORS.white,
+    backgroundImage: `linear-gradient(to right, ${COLORS.white} 100%, rgba(255,255,255,0) 0%)`,
+    color: COLORS.white,
   },
 };
 
 export const listItemContentDisabledStyles = {
-  backgroundImage: `linear-gradient(to right, ${PRIMITIVE_COLORS.gray600} 36%, rgba(255,255,255,0) 0%)`,
-  color: PRIMITIVE_COLORS.gray600,
+  backgroundImage: `linear-gradient(to right, ${COLORS.gray600} 36%, rgba(255,255,255,0) 0%)`,
+  color: COLORS.gray600,
   cursor: "not-allowed",
 
   ":hover": {
-    backgroundImage: `linear-gradient(to right, ${PRIMITIVE_COLORS.gray600} 36%, rgba(255,255,255,0) 0%)`,
-    color: PRIMITIVE_COLORS.gray600,
+    backgroundImage: `linear-gradient(to right, ${COLORS.gray600} 36%, rgba(255,255,255,0) 0%)`,
+    color: COLORS.gray600,
   },
 };
 
@@ -43,7 +43,7 @@ export const listHeadingContentStyles = {
   ...expandProperty("padding", "8px 0"),
   position: "relative",
   marginLeft: "0",
-  color: PRIMITIVE_COLORS.white,
+  color: COLORS.white,
 };
 
 export const listHeadingContainerStyles = {

--- a/src/components/menu/Menu.stories.mdx
+++ b/src/components/menu/Menu.stories.mdx
@@ -2,14 +2,14 @@ import { Canvas, Meta, Story, ArgsTable, Source } from "@storybook/blocks";
 import Menu from "./Menu";
 import { MENU_SIZE } from "./types";
 import { SearchIcon } from "../icons";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { BUTTON_KIND, Button } from "../button";
 
 <Meta title="Overlay/Menu" component={Menu} />
 
 export const Template = ({ ...args }) => {
   return (
-    <div style={{ maxWidth: "480px", padding: "32px", backgroundColor: PRIMITIVE_COLORS.black }}>
+    <div style={{ maxWidth: "480px", padding: "32px", backgroundColor: COLORS.black }}>
       <Menu {...args} />
     </div>
   );

--- a/src/components/menu/styles.ts
+++ b/src/components/menu/styles.ts
@@ -1,6 +1,6 @@
 import { StyleObject } from "styletron-react";
 import { MENU_SIZE } from "./types";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { withoutBorderStyles } from "../../shared/styles/borderStyles";
 import { expandProperty } from "inline-style-expand-shorthand";
 
@@ -10,7 +10,7 @@ export const listStyles = {
   ...expandProperty("padding", "8px"),
   ...expandProperty("boxShadow", "none"),
   outline: "none !important",
-  backgroundColor: PRIMITIVE_COLORS.gray900,
+  backgroundColor: COLORS.gray900,
 };
 
 export const headerBaseStyles: StyleObject = {
@@ -53,35 +53,35 @@ const itemModifiedStyles = {
 };
 
 const itemSelectedStyles: StyleObject = {
-  backgroundColor: PRIMITIVE_COLORS.gray800,
+  backgroundColor: COLORS.gray800,
 };
 
 const itemDisabledStyles = {
   backgroundColor: "transparent",
-  color: PRIMITIVE_COLORS.gray600,
+  color: COLORS.gray600,
   cursor: "not-allowed",
 
   ":hover": {
     backgroundColor: "transparent",
-    color: PRIMITIVE_COLORS.gray600,
+    color: COLORS.gray600,
   },
 
   ":hover > div": {
-    color: PRIMITIVE_COLORS.gray600,
+    color: COLORS.gray600,
   },
 
   ":hover > svg": {
-    fill: PRIMITIVE_COLORS.gray600,
+    fill: COLORS.gray600,
   },
 };
 
 const itemHighlightedStyles: StyleObject = {
-  backgroundColor: PRIMITIVE_COLORS.gray800,
-  color: PRIMITIVE_COLORS.white,
+  backgroundColor: COLORS.gray800,
+  color: COLORS.white,
 };
 
 export const svgActiveStyles: StyleObject = {
-  fill: PRIMITIVE_COLORS.white,
+  fill: COLORS.white,
 };
 
 export const getItemContainerStyles = (
@@ -97,21 +97,21 @@ export const getItemContainerStyles = (
     boxSizing: "border-box",
     cursor: "pointer",
     gap: "8px",
-    color: PRIMITIVE_COLORS.gray200,
+    color: COLORS.gray200,
     fontWeight: 500,
     ...expandProperty("borderRadius", "4px"),
 
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray800,
-      color: PRIMITIVE_COLORS.white,
+      backgroundColor: COLORS.gray800,
+      color: COLORS.white,
     },
 
     ":hover > div": {
-      color: PRIMITIVE_COLORS.white,
+      color: COLORS.white,
     },
 
     ":hover > svg": {
-      fill: PRIMITIVE_COLORS.white,
+      fill: COLORS.white,
     },
 
     ...itemModifiedStyles[size],
@@ -135,12 +135,12 @@ export const getLinkComponentStyles = () => {
 
 export const getItemParagraphColor = (isActive: boolean, isDisabled: boolean) => {
   if (isDisabled) {
-    return PRIMITIVE_COLORS.gray600;
+    return COLORS.gray600;
   }
   if (isActive) {
-    return PRIMITIVE_COLORS.white;
+    return COLORS.white;
   }
-  return PRIMITIVE_COLORS.gray500;
+  return COLORS.gray500;
 };
 
 export const itemTypographyStyles = {

--- a/src/components/menu/ui/MenuItem.tsx
+++ b/src/components/menu/ui/MenuItem.tsx
@@ -13,7 +13,7 @@ import {
   svgActiveStyles,
 } from "../styles";
 import { SeparatorIcon } from "../../icons";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 import { getLinkComponent } from "./getLinkComponent";
 
 const paragraphComponent = {
@@ -53,7 +53,7 @@ const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
                 className: css(isAreaSelected ? svgActiveStyles : {}),
               })}
           </EndWrapper>
-          {item?.isActive && <SeparatorIcon size={20} color={PRIMITIVE_COLORS.gray300} />}
+          {item?.isActive && <SeparatorIcon size={20} color={COLORS.gray300} />}
         </LinkComponent>
       </Item>
     );

--- a/src/components/modal/overrides.tsx
+++ b/src/components/modal/overrides.tsx
@@ -1,7 +1,7 @@
 import { ModalOverrides } from "baseui/modal";
 import { withoutBorderStyles } from "../../shared/styles/borderStyles";
 import ModalClose from "./ui/ModalClose";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 
 export const getModalOverrides = (): ModalOverrides => ({
@@ -16,7 +16,7 @@ export const getModalOverrides = (): ModalOverrides => ({
         ...withoutBorderStyles,
         ...expandProperty("padding", "32px 24px 16px"),
         ...($size === "default" ? { width: "500px" } : {}),
-        backgroundColor: PRIMITIVE_COLORS.gray800,
+        backgroundColor: COLORS.gray800,
         boxSizing: "border-box",
       };
     },

--- a/src/components/modal/ui/ModalBody.tsx
+++ b/src/components/modal/ui/ModalBody.tsx
@@ -2,7 +2,7 @@ import { FC, ReactNode } from "react";
 import { ParagraphSmall } from "baseui/typography";
 import { useStyletron } from "baseui";
 import { modalBodyStyles } from "../styles";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 
 export type ModalBodyProps = {
   children?: ReactNode;
@@ -12,7 +12,7 @@ const ModalBody: FC<ModalBodyProps> = ({ children }) => {
   const [css] = useStyletron();
   return (
     <div className={css(modalBodyStyles)}>
-      <ParagraphSmall as="div" margin={0} color={PRIMITIVE_COLORS.gray300}>
+      <ParagraphSmall as="div" margin={0} color={COLORS.gray300}>
         {children}
       </ParagraphSmall>
     </div>

--- a/src/components/modal/ui/ModalClose.tsx
+++ b/src/components/modal/ui/ModalClose.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { useStyletron } from "baseui";
 import { CloseIcon } from "../../icons";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 import { StyleObject } from "styletron-react";
 
 type DrawerCloseProps = {
@@ -31,7 +31,7 @@ const ModalClose: FC<DrawerCloseProps> = ({ ...props }) => {
 
   return (
     <button {...props} className={css(buttonStyles)}>
-      <CloseIcon size={24} color={PRIMITIVE_COLORS.white} />
+      <CloseIcon size={24} color={COLORS.white} />
     </button>
   );
 };

--- a/src/components/navigation-bar/AuthDropdownContainer.tsx
+++ b/src/components/navigation-bar/AuthDropdownContainer.tsx
@@ -2,7 +2,7 @@ import { FC, ReactNode } from "react";
 import { useStyletron } from "baseui";
 import AuthAvatar from "./ui/auth/AuthAvatar";
 import { LabelSmall } from "baseui/typography";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { LogoutIcon } from "../icons";
 import { Button, BUTTON_SIZE } from "../button";
 
@@ -41,13 +41,13 @@ const AuthDropdownContainer: FC<AuthDropdownContainerProps> = ({ username, child
         <div className={css(wrapperStyles)}>
           <div className={css(authWrapperStyles)}>
             <AuthAvatar username={username} />
-            <LabelSmall className={css(labelStyles)} color={PRIMITIVE_COLORS.gray800}>
+            <LabelSmall className={css(labelStyles)} color={COLORS.gray800}>
               {username}
             </LabelSmall>
           </div>
           <Button onClick={onLogout} size={BUTTON_SIZE.mini}>
-            <LogoutIcon color={PRIMITIVE_COLORS.gray800} />
-            <LabelSmall className={css(labelStyles)} color={PRIMITIVE_COLORS.gray800}>
+            <LogoutIcon color={COLORS.gray800} />
+            <LabelSmall className={css(labelStyles)} color={COLORS.gray800}>
               Log Out
             </LabelSmall>
           </Button>

--- a/src/components/navigation-bar/AuthItem.tsx
+++ b/src/components/navigation-bar/AuthItem.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { useStyletron } from "baseui";
 import { LabelSmall } from "baseui/typography";
 import { expandProperty } from "inline-style-expand-shorthand";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 export type AuthItemProps = {
   amount: string;
@@ -12,7 +12,7 @@ export type AuthItemProps = {
 
 const containerStyles = {
   ...expandProperty("padding", "16px"),
-  ...expandProperty("borderTop", `1px solid ${PRIMITIVE_COLORS.gray100}`),
+  ...expandProperty("borderTop", `1px solid ${COLORS.gray100}`),
 };
 
 const wrapperStyles = {
@@ -28,17 +28,17 @@ const AuthItem: FC<AuthItemProps> = ({ amount, cents, currency }) => {
 
   return (
     <div className={css(containerStyles)}>
-      <LabelSmall color={PRIMITIVE_COLORS.gray500}>Current balance</LabelSmall>
+      <LabelSmall color={COLORS.gray500}>Current balance</LabelSmall>
       <div className={css(wrapperStyles)}>
-        <LabelSmall className={css(labelStyles)} as="span" color={PRIMITIVE_COLORS.gray800}>
+        <LabelSmall className={css(labelStyles)} as="span" color={COLORS.gray800}>
           {amount}
         </LabelSmall>
         {cents && (
-          <LabelSmall className={css(labelStyles)} as="span" color={PRIMITIVE_COLORS.gray500}>
+          <LabelSmall className={css(labelStyles)} as="span" color={COLORS.gray500}>
             {cents}
           </LabelSmall>
         )}
-        <LabelSmall as="span" color={PRIMITIVE_COLORS.gray800}>
+        <LabelSmall as="span" color={COLORS.gray800}>
           {currency}
         </LabelSmall>
       </div>

--- a/src/components/navigation-bar/styles.ts
+++ b/src/components/navigation-bar/styles.ts
@@ -1,4 +1,4 @@
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { StyleObject } from "styletron-react";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { MediaQuery } from "baseui/theme";
@@ -23,7 +23,7 @@ export const navigationWrapperStyles: StyleObject = {
   width: "100%",
   height: "100%",
   minHeight: "44px",
-  backgroundColor: PRIMITIVE_COLORS.white,
+  backgroundColor: COLORS.white,
   boxSizing: "border-box",
   ...expandProperty("padding", "0 16px"),
 };
@@ -60,20 +60,20 @@ export const getNavigationBurgerStyles = (media: MediaQuery): StyleObject => ({
 
 const treeLabelDisabledStyles: StyleObject = {
   cursor: "not-allowed",
-  color: `${PRIMITIVE_COLORS.gray300} !important`,
+  color: `${COLORS.gray300} !important`,
 
   ":hover": {
-    color: `${PRIMITIVE_COLORS.gray300} !important`,
+    color: `${COLORS.gray300} !important`,
   },
 };
 
 export const getTreeLabelStyles = (isSelected: boolean, disabled: boolean): StyleObject => {
   return {
-    color: `${isSelected ? PRIMITIVE_COLORS.gray500 : PRIMITIVE_COLORS.gray800} !important`,
+    color: `${isSelected ? COLORS.gray500 : COLORS.gray800} !important`,
     textDecoration: "none !important",
 
     ":hover": {
-      color: `${isSelected ? PRIMITIVE_COLORS.gray500 : PRIMITIVE_COLORS.gray600} !important`,
+      color: `${isSelected ? COLORS.gray500 : COLORS.gray600} !important`,
     },
 
     ...(disabled ? treeLabelDisabledStyles : {}),

--- a/src/components/navigation-bar/ui/LoginBlock.tsx
+++ b/src/components/navigation-bar/ui/LoginBlock.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { useStyletron } from "baseui";
 import { LoginIcon } from "../../icons";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 import { LabelSmall } from "baseui/typography";
 import { Button, BUTTON_SIZE } from "../../button";
 
@@ -14,12 +14,12 @@ const LoginBlock: FC<LoginBlockProps> = ({ onClick }) => {
 
   return (
     <Button onClick={onClick} size={BUTTON_SIZE.mini}>
-      <LoginIcon color={PRIMITIVE_COLORS.gray800} />
+      <LoginIcon color={COLORS.gray800} />
       <LabelSmall
         className={css({
           marginLeft: "8px",
         })}
-        color={PRIMITIVE_COLORS.gray800}
+        color={COLORS.gray800}
       >
         Sign in
       </LabelSmall>

--- a/src/components/navigation-bar/ui/auth/AvatarBlock.tsx
+++ b/src/components/navigation-bar/ui/auth/AvatarBlock.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode, useState } from "react";
 import { Button, BUTTON_SIZE } from "../../../button";
-import { PRIMITIVE_COLORS } from "../../../../shared";
+import { COLORS } from "../../../../shared";
 import { CaretDownIcon, CaretUpIcon } from "../../../icons";
 import AuthAvatar from "./AuthAvatar";
 import NavPopover from "../NavPopover";
@@ -13,7 +13,7 @@ type AvatarBlockProps = {
 
 const iconProps = {
   size: 16,
-  color: PRIMITIVE_COLORS.gray800,
+  color: COLORS.gray800,
 };
 
 const AvatarBlock: FC<AvatarBlockProps> = ({ username, authDropdownContainer }) => {

--- a/src/components/navigation-bar/ui/auth/overrides.ts
+++ b/src/components/navigation-bar/ui/auth/overrides.ts
@@ -1,5 +1,5 @@
 import { AvatarOverrides } from "baseui/avatar";
-import { PRIMITIVE_COLORS } from "../../../../shared";
+import { COLORS } from "../../../../shared";
 import { PopoverOverrides } from "baseui/popover";
 import { expandProperty } from "inline-style-expand-shorthand";
 
@@ -7,7 +7,7 @@ export const getAvatarOverrides = (): AvatarOverrides => {
   return {
     Root: {
       style: {
-        backgroundColor: PRIMITIVE_COLORS.gray100,
+        backgroundColor: COLORS.gray100,
         marginRight: "4px",
       },
     },
@@ -15,7 +15,7 @@ export const getAvatarOverrides = (): AvatarOverrides => {
       style: {
         fontSize: "14px",
         lineHeight: "16px",
-        color: PRIMITIVE_COLORS.gray800,
+        color: COLORS.gray800,
       },
     },
   };
@@ -31,7 +31,7 @@ export const getPopoverOverrides = (): PopoverOverrides => {
     },
     Inner: {
       style: {
-        backgroundColor: PRIMITIVE_COLORS.white,
+        backgroundColor: COLORS.white,
         ...expandProperty("borderRadius", "0"),
       },
     },

--- a/src/components/navigation-bar/ui/brand/Brand.tsx
+++ b/src/components/navigation-bar/ui/brand/Brand.tsx
@@ -1,12 +1,12 @@
 import { FC, memo } from "react";
-import { PRIMITIVE_COLORS } from "../../../../shared";
+import { COLORS } from "../../../../shared";
 
 export type BrandProps = {
   color?: string;
   className?: string;
 };
 
-export const Brand: FC<BrandProps> = ({ color = PRIMITIVE_COLORS.gray800, className }) => {
+export const Brand: FC<BrandProps> = ({ color = COLORS.gray800, className }) => {
   return (
     <svg
       className={className}

--- a/src/components/navigation-bar/ui/menu-navigation/NavItem.tsx
+++ b/src/components/navigation-bar/ui/menu-navigation/NavItem.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode, useState } from "react";
 import { LabelSmall } from "baseui/typography";
-import { PRIMITIVE_COLORS } from "../../../../shared";
+import { COLORS } from "../../../../shared";
 import { useStyletron } from "baseui";
 import NavPopover from "../NavPopover";
 import { Menu } from "../../../menu";
@@ -47,7 +47,7 @@ const NavItem: FC<NavItemProps> = ({ item, onItemClick, itemAs }) => {
     className: css({
       marginLeft: "4px",
     }),
-    color: disabled ? PRIMITIVE_COLORS.gray300 : PRIMITIVE_COLORS.gray800,
+    color: disabled ? COLORS.gray300 : COLORS.gray800,
     size: 16,
   };
 

--- a/src/components/navigation-bar/ui/menu-navigation/styles.ts
+++ b/src/components/navigation-bar/ui/menu-navigation/styles.ts
@@ -1,8 +1,8 @@
 import { StyleObject } from "styletron-react";
-import { PRIMITIVE_COLORS } from "../../../../shared";
+import { COLORS } from "../../../../shared";
 
 const getColor = (isSelected: boolean, isDisabled: boolean) => {
-  return isDisabled ? PRIMITIVE_COLORS.gray300 : isSelected ? PRIMITIVE_COLORS.gray500 : PRIMITIVE_COLORS.gray800;
+  return isDisabled ? COLORS.gray300 : isSelected ? COLORS.gray500 : COLORS.gray800;
 };
 
 export const getListItemStyles = (isSelected: boolean, isDisabled: boolean): StyleObject => {
@@ -14,15 +14,15 @@ export const getListItemStyles = (isSelected: boolean, isDisabled: boolean): Sty
     textDecoration: "none !important",
 
     ":hover": {
-      color: `${isDisabled ? PRIMITIVE_COLORS.gray300 : PRIMITIVE_COLORS.gray600} !important`,
+      color: `${isDisabled ? COLORS.gray300 : COLORS.gray600} !important`,
     },
 
     ":focus": {
-      color: `${isDisabled ? PRIMITIVE_COLORS.gray300 : PRIMITIVE_COLORS.gray500} !important`,
+      color: `${isDisabled ? COLORS.gray300 : COLORS.gray500} !important`,
     },
 
     ":active": {
-      color: `${isDisabled ? PRIMITIVE_COLORS.gray300 : PRIMITIVE_COLORS.gray500} !important`,
+      color: `${isDisabled ? COLORS.gray300 : COLORS.gray500} !important`,
     },
   };
 };
@@ -37,10 +37,10 @@ export const getButtonStyles = (isSelected: boolean, isDisabled: boolean) => ({
   color: getColor(isSelected, isDisabled),
 
   ":hover": {
-    color: `${isDisabled ? PRIMITIVE_COLORS.gray300 : PRIMITIVE_COLORS.gray600} !important`,
+    color: `${isDisabled ? COLORS.gray300 : COLORS.gray600} !important`,
   },
 
   ":focus": {
-    color: `${PRIMITIVE_COLORS.gray500} !important`,
+    color: `${COLORS.gray500} !important`,
   },
 });

--- a/src/components/navigation-bar/ui/side-navigation/SideNavigationHeader.tsx
+++ b/src/components/navigation-bar/ui/side-navigation/SideNavigationHeader.tsx
@@ -2,7 +2,7 @@ import { FC, ReactNode } from "react";
 import { useStyletron } from "baseui";
 import { Button, BUTTON_SIZE } from "../../../button";
 import { CloseIcon } from "../../../icons";
-import { PRIMITIVE_COLORS } from "../../../../shared";
+import { COLORS } from "../../../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 
 type SideNavigationHeaderProps = {
@@ -25,7 +25,7 @@ const SideNavigationHeader: FC<SideNavigationHeaderProps> = ({ brand, onClose })
     >
       {brand}
       <Button size={BUTTON_SIZE.mini} onClick={() => onClose?.({ closeSource: "closeButton" })}>
-        <CloseIcon color={PRIMITIVE_COLORS.gray800} size={24} />
+        <CloseIcon color={COLORS.gray800} size={24} />
       </Button>
     </div>
   );

--- a/src/components/navigation-bar/ui/side-navigation/overrides.tsx
+++ b/src/components/navigation-bar/ui/side-navigation/overrides.tsx
@@ -1,6 +1,6 @@
 import { TreeViewOverrides } from "baseui/tree-view";
 import { expandProperty } from "inline-style-expand-shorthand";
-import { PRIMITIVE_COLORS } from "../../../../shared";
+import { COLORS } from "../../../../shared";
 import { CaretDownIcon, CaretUpIcon } from "../../../icons";
 import NavTreeLabel from "./NavTreeLabel";
 import { NavigationItem } from "../../types";
@@ -11,7 +11,7 @@ export const getDrawerOverrides = (): DrawerOverrides => {
   return {
     DrawerContainer: {
       style: {
-        backgroundColor: PRIMITIVE_COLORS.white,
+        backgroundColor: COLORS.white,
       },
     },
     DrawerBody: {
@@ -43,13 +43,13 @@ export const getTreeViewOverrides = (itemAs?: (item: NavigationItem) => ReactNod
       style: ({ $hasChildren }) => {
         return {
           ...expandProperty("padding", "16px 8px"),
-          ...expandProperty("borderBottom", `1px solid ${PRIMITIVE_COLORS.gray100}`),
+          ...expandProperty("borderBottom", `1px solid ${COLORS.gray100}`),
           color: "inherit",
           marginLeft: !$hasChildren ? "-20px" : "0",
-          backgroundColor: PRIMITIVE_COLORS.white,
+          backgroundColor: COLORS.white,
 
           ":hover": {
-            backgroundColor: PRIMITIVE_COLORS.white,
+            backgroundColor: COLORS.white,
           },
         };
       },

--- a/src/components/notification/Notification.tsx
+++ b/src/components/notification/Notification.tsx
@@ -5,7 +5,7 @@ import { NOTIFICATION_KIND, NotificationProps } from "./types";
 import NotificationContent from "./ui/NotificationContent";
 import { CancelIcon, CompleteIcon, IconProps, InfoIcon, WarningIcon } from "../icons";
 import { Button, BUTTON_KIND, BUTTON_SIZE } from "../button";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { getMergedOverrides } from "../../shared/utils/getMergedOverrides";
 
 const semanticIcon = {
@@ -18,16 +18,16 @@ const semanticIcon = {
 const actionColors = {
   [NOTIFICATION_KIND.info]: undefined,
   [NOTIFICATION_KIND.warning]: {
-    backgroundColor: PRIMITIVE_COLORS.yellow600,
-    color: PRIMITIVE_COLORS.white,
+    backgroundColor: COLORS.yellow600,
+    color: COLORS.white,
   },
   [NOTIFICATION_KIND.negative]: {
-    backgroundColor: PRIMITIVE_COLORS.red600,
-    color: PRIMITIVE_COLORS.white,
+    backgroundColor: COLORS.red600,
+    color: COLORS.white,
   },
   [NOTIFICATION_KIND.positive]: {
-    backgroundColor: PRIMITIVE_COLORS.green600,
-    color: PRIMITIVE_COLORS.white,
+    backgroundColor: COLORS.green600,
+    color: COLORS.white,
   },
 };
 

--- a/src/components/notification/overrides.tsx
+++ b/src/components/notification/overrides.tsx
@@ -1,7 +1,7 @@
 import { ToastOverrides } from "baseui/toast";
 import { NOTIFICATION_KIND } from "./types";
 import { notificationBodyModifiedStyles } from "./styles";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { withoutBorderStyles } from "../../shared/styles/borderStyles";
 
@@ -11,7 +11,7 @@ export const getNotificationOverrides = (): ToastOverrides => {
       style: ({ $kind }) => {
         const modifiedStyles = notificationBodyModifiedStyles?.[$kind as NOTIFICATION_KIND] ?? {};
         return {
-          color: PRIMITIVE_COLORS.white,
+          color: COLORS.white,
           ...withoutBorderStyles,
           ...expandProperty("padding", "16px 20px"),
           ...modifiedStyles,

--- a/src/components/notification/styles.ts
+++ b/src/components/notification/styles.ts
@@ -1,18 +1,18 @@
 import { NOTIFICATION_KIND } from "./types";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 export const notificationBodyModifiedStyles = {
   [NOTIFICATION_KIND.info]: {
-    backgroundColor: PRIMITIVE_COLORS.mono600,
+    backgroundColor: COLORS.mono600,
   },
   [NOTIFICATION_KIND.warning]: {
-    backgroundColor: PRIMITIVE_COLORS.yellow700,
+    backgroundColor: COLORS.yellow700,
   },
   [NOTIFICATION_KIND.positive]: {
-    backgroundColor: PRIMITIVE_COLORS.green700,
+    backgroundColor: COLORS.green700,
   },
   [NOTIFICATION_KIND.negative]: {
-    backgroundColor: PRIMITIVE_COLORS.red700,
+    backgroundColor: COLORS.red700,
   },
 };
 

--- a/src/components/progress-bar/styles.ts
+++ b/src/components/progress-bar/styles.ts
@@ -1,6 +1,6 @@
 import { StyleObject } from "styletron-react";
 import { PROGRESS_BAR_SIZE } from "./types";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 export const containerStyles: StyleObject = {
   display: "flex",
@@ -31,15 +31,15 @@ export const dashedBlockStyles: StyleObject = {
 };
 
 export const dashedBlockActiveStyles: StyleObject = {
-  backgroundImage: `linear-gradient(to right, ${PRIMITIVE_COLORS.white} 50%, transparent 50%)`,
+  backgroundImage: `linear-gradient(to right, ${COLORS.white} 50%, transparent 50%)`,
 };
 
 export const dashedBlockErrorStyles: StyleObject = {
-  backgroundImage: `linear-gradient(to right, ${PRIMITIVE_COLORS.red400} 50%, transparent 50%)`,
+  backgroundImage: `linear-gradient(to right, ${COLORS.red400} 50%, transparent 50%)`,
 };
 
 export const dashedBlockNotActiveStyles: StyleObject = {
-  backgroundImage: `linear-gradient(to right, ${PRIMITIVE_COLORS.gray700} 50%, transparent 50%)`,
+  backgroundImage: `linear-gradient(to right, ${COLORS.gray700} 50%, transparent 50%)`,
 };
 
 export const labelStyles: StyleObject = {

--- a/src/components/radio/overrides.tsx
+++ b/src/components/radio/overrides.tsx
@@ -1,5 +1,5 @@
 import { RadioOverrides } from "baseui/radio";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import {
   getRadioMarkInnerErrorStyles,
   getRadioMarkInnerStyles,
@@ -30,12 +30,12 @@ export const getRadioOverrides = (): RadioOverrides => ({
   },
   Label: {
     style: ({ $disabled }) => ({
-      color: $disabled ? PRIMITIVE_COLORS.gray300 : PRIMITIVE_COLORS.white,
+      color: $disabled ? COLORS.gray300 : COLORS.white,
     }),
   },
   Description: {
     style: ({ $disabled }) => ({
-      color: $disabled ? PRIMITIVE_COLORS.gray300 : PRIMITIVE_COLORS.white,
+      color: $disabled ? COLORS.gray300 : COLORS.white,
     }),
   },
 });

--- a/src/components/radio/styles.ts
+++ b/src/components/radio/styles.ts
@@ -1,15 +1,15 @@
 import { StyleObject } from "styletron-react";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 
 export const getRadioMarkOuterStyles = (isChecked: boolean, isFocused: boolean): StyleObject => {
-  const backgroundColor = isChecked ? PRIMITIVE_COLORS.white : PRIMITIVE_COLORS.gray500;
-  const backgroundColorHover = isChecked ? PRIMITIVE_COLORS.gray50 : PRIMITIVE_COLORS.gray500;
+  const backgroundColor = isChecked ? COLORS.white : COLORS.gray500;
+  const backgroundColorHover = isChecked ? COLORS.gray50 : COLORS.gray500;
 
   return {
     width: "19px",
     height: "19px",
-    backgroundColor: isFocused ? PRIMITIVE_COLORS.gray100 : backgroundColor,
+    backgroundColor: isFocused ? COLORS.gray100 : backgroundColor,
     ...expandProperty("margin", "1px"),
 
     ":hover": {
@@ -19,11 +19,11 @@ export const getRadioMarkOuterStyles = (isChecked: boolean, isFocused: boolean):
 };
 
 export const getRadioMarkOuterErrorStyles = (isChecked: boolean, isFocused: boolean): StyleObject => {
-  const backgroundColor = isChecked ? PRIMITIVE_COLORS.red500 : PRIMITIVE_COLORS.red400;
-  const backgroundColorHover = isChecked ? PRIMITIVE_COLORS.red600 : PRIMITIVE_COLORS.red400;
+  const backgroundColor = isChecked ? COLORS.red500 : COLORS.red400;
+  const backgroundColorHover = isChecked ? COLORS.red600 : COLORS.red400;
 
   return {
-    backgroundColor: isFocused ? PRIMITIVE_COLORS.red700 : backgroundColor,
+    backgroundColor: isFocused ? COLORS.red700 : backgroundColor,
 
     ":hover": {
       backgroundColor: backgroundColorHover,
@@ -32,10 +32,10 @@ export const getRadioMarkOuterErrorStyles = (isChecked: boolean, isFocused: bool
 };
 
 export const radioMarkOuterDisabledStyles = {
-  backgroundColor: PRIMITIVE_COLORS.gray700,
+  backgroundColor: COLORS.gray700,
 
   ":hover": {
-    backgroundColor: PRIMITIVE_COLORS.gray700,
+    backgroundColor: COLORS.gray700,
   },
 };
 
@@ -43,29 +43,29 @@ export const getRadioMarkInnerStyles = (isChecked: boolean): StyleObject => {
   return {
     width: isChecked ? "6px" : "15px",
     height: isChecked ? "6px" : "15px",
-    backgroundColor: PRIMITIVE_COLORS.black,
+    backgroundColor: COLORS.black,
     ...expandProperty("borderRadius", isChecked ? "0" : "50%"),
 
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray800,
+      backgroundColor: COLORS.gray800,
     },
   };
 };
 
 export const getRadioMarkInnerErrorStyles = (isChecked: boolean): StyleObject => {
   return {
-    backgroundColor: isChecked ? PRIMITIVE_COLORS.black : PRIMITIVE_COLORS.red700,
+    backgroundColor: isChecked ? COLORS.black : COLORS.red700,
 
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.red600,
+      backgroundColor: COLORS.red600,
     },
   };
 };
 
 export const radioMarkInnerDisabledStyles = {
-  backgroundColor: PRIMITIVE_COLORS.black,
+  backgroundColor: COLORS.black,
 
   ":hover": {
-    backgroundColor: PRIMITIVE_COLORS.black,
+    backgroundColor: COLORS.black,
   },
 };

--- a/src/components/select/overrides.tsx
+++ b/src/components/select/overrides.tsx
@@ -3,7 +3,7 @@ import SelectArrow from "./ui/SelectArrow";
 import MenuItem from "../menu/ui/MenuItem";
 import { SELECT_KIND, SELECT_SIZE } from "./types";
 import SelectSpinner from "./ui/SelectSpinner";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { controlContainerModifiedStyles, selectTypographyStyles, valueContainerModifiedStyles } from "./styles";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { Tag, TAG_SIZE } from "../tag";
@@ -65,7 +65,7 @@ export const getSelectOverrides = (
     Dropdown: {
       style: () => ({
         ...expandProperty("borderRadius", "8px"),
-        backgroundColor: PRIMITIVE_COLORS.gray800,
+        backgroundColor: COLORS.gray800,
       }),
     },
     Popover: {
@@ -130,7 +130,7 @@ export const getSelectOverrides = (
         color: getColor($isFocused, $error, $disabled),
         ...selectTypographyStyles[size],
         ":focus-within": {
-          color: PRIMITIVE_COLORS.gray50,
+          color: COLORS.gray50,
         },
       }),
     },

--- a/src/components/select/ui/SelectArrow.tsx
+++ b/src/components/select/ui/SelectArrow.tsx
@@ -1,6 +1,6 @@
 import { FC, memo, useContext } from "react";
 import { useStyletron } from "baseui";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 import { ChevronDownIcon } from "../../icons";
 import SelectContext from "../SelectContext";
 
@@ -10,7 +10,7 @@ type SelectArrowProps = {
   searchable?: boolean;
 };
 
-const SelectArrow: FC<SelectArrowProps> = ({ color = PRIMITIVE_COLORS.white, isRotated, searchable, ...restProps }) => {
+const SelectArrow: FC<SelectArrowProps> = ({ color = COLORS.white, isRotated, searchable, ...restProps }) => {
   const [css] = useStyletron();
   const { controlRef } = useContext(SelectContext);
   const onClick = () => {

--- a/src/components/spinner/ui/SpinnerIcon.tsx
+++ b/src/components/spinner/ui/SpinnerIcon.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 import { styled, useStyletron } from "baseui";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 
 type SpinnerIconProps = {
   size?: string;
@@ -87,7 +87,7 @@ const rectList: TRect[] = [
 ];
 
 const SpinnerIcon = forwardRef<SVGSVGElement, SpinnerIconProps>(
-  ({ size = "12", color = PRIMITIVE_COLORS.white, animation }, ref) => {
+  ({ size = "12", color = COLORS.white, animation }, ref) => {
     const [css] = useStyletron();
 
     const RectItem = styled("rect", {

--- a/src/components/table/Table.stories.mdx
+++ b/src/components/table/Table.stories.mdx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import Table from "./TableSemantic";
 import { TABLE_DIVIDER, TABLE_SIZE } from "./types";
 import { useStyletron } from "baseui";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import TableSemanticBuilder from "./TableSemanticBuilder";
 import TableSemanticBuilderColumn from "./TableSemanticBuilderColumn";
 import { Checkbox } from "../checkbox";
@@ -48,7 +48,7 @@ export const Template = ({ ...args }) => {
     <div
       className={css({
         maxWidth: "650px",
-        backgroundColor: PRIMITIVE_COLORS.gray900,
+        backgroundColor: COLORS.gray900,
         padding: "24px",
         borderRadius: "8px",
       })}
@@ -86,7 +86,7 @@ export const TableSemanticBuilderTemplate = ({ ...args }) => {
     <div
       className={css({
         maxWidth: "650px",
-        backgroundColor: PRIMITIVE_COLORS.gray900,
+        backgroundColor: COLORS.gray900,
         padding: "24px",
         borderRadius: "8px",
       })}

--- a/src/components/table/overrides.tsx
+++ b/src/components/table/overrides.tsx
@@ -1,5 +1,5 @@
 import { TableOverrides } from "baseui/table-semantic";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { TABLE_DIVIDER } from "./types";
 import { ChevronDownIcon, ChevronUpIcon } from "../icons";
 import { expandProperty } from "inline-style-expand-shorthand";
@@ -10,26 +10,26 @@ export const rootStyles = {
 };
 
 export const tableHeadStyles = {
-  ...expandProperty("borderBottom", `1px solid ${PRIMITIVE_COLORS.gray800}`),
+  ...expandProperty("borderBottom", `1px solid ${COLORS.gray800}`),
 };
 
 export const tableHeadRowStyles = {
-  ...expandProperty("borderBottom", `1px solid ${PRIMITIVE_COLORS.gray800}`),
+  ...expandProperty("borderBottom", `1px solid ${COLORS.gray800}`),
 };
 
 export const tableHeadCellSortableStyles = ({ $divider }: any) => {
   return {
     backgroundColor: "transparent",
-    color: PRIMITIVE_COLORS.gray300,
-    borderBottom: $divider !== TABLE_DIVIDER.clean ? `1px solid ${PRIMITIVE_COLORS.gray800}` : "none",
+    color: COLORS.gray300,
+    borderBottom: $divider !== TABLE_DIVIDER.clean ? `1px solid ${COLORS.gray800}` : "none",
   };
 };
 
 export const tableHeadCellStyles = ({ $divider, $size }: any) => {
   return {
     backgroundColor: "transparent",
-    color: PRIMITIVE_COLORS.gray400,
-    borderBottom: $divider !== TABLE_DIVIDER.clean ? `1px solid ${PRIMITIVE_COLORS.gray800}` : "none",
+    color: COLORS.gray400,
+    borderBottom: $divider !== TABLE_DIVIDER.clean ? `1px solid ${COLORS.gray800}` : "none",
     fontSize: "12px",
     fontWeight: 500,
     lineHeight: "16px",
@@ -44,7 +44,7 @@ export const tableBodyStyles = {
 export const tableBodyCellStyles = ({ $size }: any) => ({
   fontSize: "14px",
   lineHeight: "20px",
-  color: PRIMITIVE_COLORS.gray200,
+  color: COLORS.gray200,
   border: "none",
   padding: $size === "compact" ? "8px 12px" : "12px",
   ":hover": {

--- a/src/components/tabs/styles.ts
+++ b/src/components/tabs/styles.ts
@@ -1,4 +1,4 @@
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { withoutMarginStyles } from "../../shared/styles/withoutMarginStyles";
 import { expandProperty } from "inline-style-expand-shorthand";
 
@@ -6,39 +6,39 @@ export const tabBaseStyles = {
   ...withoutMarginStyles,
   paddingLeft: "24px",
   paddingRight: "24px",
-  color: PRIMITIVE_COLORS.white,
+  color: COLORS.white,
 
   ":hover": {
-    borderColor: PRIMITIVE_COLORS.gray700,
-    backgroundColor: PRIMITIVE_COLORS.gray800,
+    borderColor: COLORS.gray700,
+    backgroundColor: COLORS.gray800,
   },
 };
 
 export const tabStyles = {
   ...tabBaseStyles,
-  borderBottom: `4px solid ${PRIMITIVE_COLORS.gray500}`,
+  borderBottom: `4px solid ${COLORS.gray500}`,
 };
 
 export const tabVerticalStyles = {
   ...tabBaseStyles,
-  borderRight: `4px solid ${PRIMITIVE_COLORS.gray500}`,
+  borderRight: `4px solid ${COLORS.gray500}`,
   borderBottom: "none",
 };
 
 export const tabActiveStyles = {
-  borderColor: `${PRIMITIVE_COLORS.white} !important`,
+  borderColor: `${COLORS.white} !important`,
 
   ":hover": {
-    borderColor: `${PRIMITIVE_COLORS.white} !important`,
+    borderColor: `${COLORS.white} !important`,
   },
 };
 
 export const tabDisabledStyles = {
-  borderColor: PRIMITIVE_COLORS.gray500,
-  color: PRIMITIVE_COLORS.gray600,
+  borderColor: COLORS.gray500,
+  color: COLORS.gray600,
 
   ":hover": {
-    borderColor: PRIMITIVE_COLORS.gray500,
+    borderColor: COLORS.gray500,
     backgroundColor: "transparent",
   },
 };
@@ -48,7 +48,7 @@ export const tabsBarStyles = {
 };
 
 export const tabContentStyles = {
-  color: PRIMITIVE_COLORS.white,
+  color: COLORS.white,
   ...expandProperty("padding", "24px"),
 };
 

--- a/src/components/tag/styles.ts
+++ b/src/components/tag/styles.ts
@@ -1,6 +1,6 @@
 import { expandProperty } from "inline-style-expand-shorthand";
 import { TAG_KIND } from "./types";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { withoutBorderStyles } from "../../shared/styles/borderStyles";
 import { withoutMarginStyles } from "../../shared/styles/withoutMarginStyles";
 
@@ -8,7 +8,7 @@ export const tagRootBaseStyles = {
   ...withoutBorderStyles,
   ...withoutMarginStyles,
   fontWeight: 500,
-  color: PRIMITIVE_COLORS.gray50,
+  color: COLORS.gray50,
   fontSize: "12px",
   lineHeight: "16px",
   cursor: "text",
@@ -27,26 +27,26 @@ export const mediumStyles = {
 
 export const tagRootFillKindModifiedStyles = {
   [TAG_KIND.gray]: {
-    backgroundColor: PRIMITIVE_COLORS.gray600,
+    backgroundColor: COLORS.gray600,
   },
   [TAG_KIND.blue]: {
-    backgroundColor: PRIMITIVE_COLORS.blue500,
+    backgroundColor: COLORS.blue500,
   },
   [TAG_KIND.green]: {
-    backgroundColor: PRIMITIVE_COLORS.green500,
+    backgroundColor: COLORS.green500,
   },
   [TAG_KIND.yellow]: {
-    backgroundColor: PRIMITIVE_COLORS.yellow500,
+    backgroundColor: COLORS.yellow500,
   },
   [TAG_KIND.purple]: {
-    backgroundColor: PRIMITIVE_COLORS.purple500,
+    backgroundColor: COLORS.purple500,
   },
   [TAG_KIND.red]: {
-    backgroundColor: PRIMITIVE_COLORS.red500,
+    backgroundColor: COLORS.red500,
   },
   [TAG_KIND.white]: {
-    backgroundColor: PRIMITIVE_COLORS.gray50,
-    color: PRIMITIVE_COLORS.gray900,
+    backgroundColor: COLORS.gray50,
+    color: COLORS.gray900,
   },
 };
 
@@ -56,31 +56,31 @@ export const tagRootFillBaseStyles = {
 
 export const tagRootKindModifiedStyles = {
   [TAG_KIND.gray]: {
-    color: PRIMITIVE_COLORS.gray300,
-    ...expandProperty("border", `1px solid ${PRIMITIVE_COLORS.gray300}`),
+    color: COLORS.gray300,
+    ...expandProperty("border", `1px solid ${COLORS.gray300}`),
   },
   [TAG_KIND.blue]: {
-    color: PRIMITIVE_COLORS.blue300,
-    ...expandProperty("border", `1px solid ${PRIMITIVE_COLORS.blue300}`),
+    color: COLORS.blue300,
+    ...expandProperty("border", `1px solid ${COLORS.blue300}`),
   },
   [TAG_KIND.green]: {
-    color: PRIMITIVE_COLORS.green300,
-    ...expandProperty("border", `1px solid ${PRIMITIVE_COLORS.green300}`),
+    color: COLORS.green300,
+    ...expandProperty("border", `1px solid ${COLORS.green300}`),
   },
   [TAG_KIND.yellow]: {
-    color: PRIMITIVE_COLORS.yellow300,
-    ...expandProperty("border", `1px solid ${PRIMITIVE_COLORS.yellow300}`),
+    color: COLORS.yellow300,
+    ...expandProperty("border", `1px solid ${COLORS.yellow300}`),
   },
   [TAG_KIND.purple]: {
-    color: PRIMITIVE_COLORS.purple300,
-    ...expandProperty("border", `1px solid ${PRIMITIVE_COLORS.purple300}`),
+    color: COLORS.purple300,
+    ...expandProperty("border", `1px solid ${COLORS.purple300}`),
   },
   [TAG_KIND.red]: {
-    color: PRIMITIVE_COLORS.red300,
-    ...expandProperty("border", `1px solid ${PRIMITIVE_COLORS.red300}`),
+    color: COLORS.red300,
+    ...expandProperty("border", `1px solid ${COLORS.red300}`),
   },
   [TAG_KIND.white]: {
-    color: PRIMITIVE_COLORS.gray50,
-    ...expandProperty("border", `1px solid ${PRIMITIVE_COLORS.gray50}`),
+    color: COLORS.gray50,
+    ...expandProperty("border", `1px solid ${COLORS.gray50}`),
   },
 };

--- a/src/components/textarea/ui/TextareaResizeIcon.tsx
+++ b/src/components/textarea/ui/TextareaResizeIcon.tsx
@@ -1,14 +1,14 @@
 import { FC } from "react";
 import { useStyletron } from "baseui";
 import { ResizeIcon } from "../../icons";
-import { PRIMITIVE_COLORS } from "../../../shared";
+import { COLORS } from "../../../shared";
 
 const TextareaResizeIcon: FC = () => {
   const [css] = useStyletron();
 
   return (
     <div className={css({ position: "absolute", bottom: "0", right: "4px", pointerEvents: "none" })}>
-      <ResizeIcon size={20} color={PRIMITIVE_COLORS.gray500} />
+      <ResizeIcon size={20} color={COLORS.gray500} />
     </div>
   );
 };

--- a/src/components/toggle/overrides.tsx
+++ b/src/components/toggle/overrides.tsx
@@ -1,5 +1,5 @@
 import { CheckboxOverrides } from "baseui/checkbox";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 import { boxShadowFocusStyles } from "../../shared/styles/boxShadowSharedStyles";
 import { getCheckmarkLabelStyles } from "../../shared/theme/checkmarkCommonLabelStyles";
@@ -26,7 +26,7 @@ export const getToggleOverrides = (disabled?: boolean): CheckboxOverrides => {
     },
     Toggle: {
       style: ({ $checked }) => ({
-        backgroundColor: PRIMITIVE_COLORS.gray800,
+        backgroundColor: COLORS.gray800,
         ...expandProperty("transition", "transform 0.15s ease-in"),
         width: "12px",
         height: "12px",

--- a/src/components/toggle/styles.ts
+++ b/src/components/toggle/styles.ts
@@ -1,5 +1,5 @@
 import { StyleObject } from "styletron-standard";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 
 export const getSwitchBackgroundStyles = (isChecked: boolean, $disabled: boolean): StyleObject => {
@@ -7,32 +7,32 @@ export const getSwitchBackgroundStyles = (isChecked: boolean, $disabled: boolean
 
   if ($disabled) {
     return {
-      backgroundColor: PRIMITIVE_COLORS.gray500,
+      backgroundColor: COLORS.gray500,
       ...transition,
     };
   }
 
   if (isChecked) {
     return {
-      backgroundColor: PRIMITIVE_COLORS.green200,
+      backgroundColor: COLORS.green200,
       ...transition,
       ":hover": {
-        backgroundColor: PRIMITIVE_COLORS.green100,
+        backgroundColor: COLORS.green100,
       },
       ":active": {
-        backgroundColor: PRIMITIVE_COLORS.green50,
+        backgroundColor: COLORS.green50,
       },
     };
   }
 
   return {
-    backgroundColor: PRIMITIVE_COLORS.gray200,
+    backgroundColor: COLORS.gray200,
     ...transition,
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray100,
+      backgroundColor: COLORS.gray100,
     },
     ":active": {
-      backgroundColor: PRIMITIVE_COLORS.gray50,
+      backgroundColor: COLORS.gray50,
     },
   };
 };

--- a/src/components/tooltip/overrides.tsx
+++ b/src/components/tooltip/overrides.tsx
@@ -1,6 +1,6 @@
 import { PopoverOverrides } from "baseui/popover";
 import { TOOLTIP_KIND } from "./types";
-import { PRIMITIVE_COLORS, SPACE } from "../../shared";
+import { COLORS, SPACE } from "../../shared";
 import { expandProperty } from "inline-style-expand-shorthand";
 
 const borderRadiusStyles = expandProperty("borderRadius", "8px");
@@ -22,7 +22,7 @@ export const getTooltipOverrides = (kind: TOOLTIP_KIND): PopoverOverrides => {
         lineHeight: "16px",
         fontSize: "12px",
         fontWeight: 500,
-        color: PRIMITIVE_COLORS.gray900,
+        color: COLORS.gray900,
         ...expandProperty("padding", SPACE[12]),
         ...getBackgroundKindStyles(kind),
       },
@@ -42,15 +42,15 @@ const getBackgroundKindStyles = (kind: TOOLTIP_KIND) => {
   switch (kind) {
     case TOOLTIP_KIND.SUCCESS:
       return {
-        backgroundColor: PRIMITIVE_COLORS.green200,
+        backgroundColor: COLORS.green200,
       };
     case TOOLTIP_KIND.ERROR:
       return {
-        backgroundColor: PRIMITIVE_COLORS.red200,
+        backgroundColor: COLORS.red200,
       };
     default:
       return {
-        backgroundColor: PRIMITIVE_COLORS.gray50,
+        backgroundColor: COLORS.gray50,
       };
   }
 };

--- a/src/components/tooltip/styles.ts
+++ b/src/components/tooltip/styles.ts
@@ -1,19 +1,19 @@
 import { withoutBorderStyles } from "../../shared/styles/borderStyles";
-import { PRIMITIVE_COLORS } from "../../shared";
+import { COLORS } from "../../shared";
 
 export const tooltipBodyStyles = {
   ...withoutBorderStyles,
-  backgroundColor: PRIMITIVE_COLORS.gray700,
+  backgroundColor: COLORS.gray700,
   maxWidth: "216px",
 };
 
 export const tooltipInnerStyles = {
-  backgroundColor: PRIMITIVE_COLORS.gray700,
-  color: PRIMITIVE_COLORS.white,
+  backgroundColor: COLORS.gray700,
+  color: COLORS.white,
   textAlign: "center",
   lineHeight: "20px",
 };
 
 export const tooltipArrowStyles = {
-  backgroundColor: PRIMITIVE_COLORS.gray700,
+  backgroundColor: COLORS.gray700,
 };

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,2 +1,2 @@
-export { createTheme, COLORS, svgInlineDotsPattern, SPACE } from "./theme";
+export { createTheme, COLORS, PRIMITIVE_COLORS, svgInlineDotsPattern, SPACE } from "./theme";
 export type { CreateTheme, CreateThemeOptions, CreateThemeReturnType, DefaultFonts } from "./theme";

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,2 +1,2 @@
-export { createTheme, PRIMITIVE_COLORS, svgInlineDotsPattern, SPACE } from "./theme";
+export { createTheme, COLORS, svgInlineDotsPattern, SPACE } from "./theme";
 export type { CreateTheme, CreateThemeOptions, CreateThemeReturnType, DefaultFonts } from "./theme";

--- a/src/shared/styles/boxShadowSharedStyles.ts
+++ b/src/shared/styles/boxShadowSharedStyles.ts
@@ -1,9 +1,9 @@
-import { PRIMITIVE_COLORS } from "../theme";
+import { COLORS } from "../theme";
 
 export const boxShadowFocusStyles = {
-  boxShadow: `0px 0px 0px 2px ${PRIMITIVE_COLORS.gray900}, 0px 0px 0px 4px ${PRIMITIVE_COLORS.gray50}`,
+  boxShadow: `0px 0px 0px 2px ${COLORS.gray900}, 0px 0px 0px 4px ${COLORS.gray50}`,
 };
 
 export const boxShadowErrorStyles = {
-  boxShadow: `0px 0px 0px 2px ${PRIMITIVE_COLORS.gray900}, 0px 0px 0px 4px ${PRIMITIVE_COLORS.red400}`,
+  boxShadow: `0px 0px 0px 2px ${COLORS.gray900}, 0px 0px 0px 4px ${COLORS.red400}`,
 };

--- a/src/shared/styles/resetAutoCompleteStyles.ts
+++ b/src/shared/styles/resetAutoCompleteStyles.ts
@@ -1,12 +1,12 @@
 import { StyleObject } from "styletron-standard";
 import { expandProperty } from "inline-style-expand-shorthand";
-import { PRIMITIVE_COLORS } from "../theme";
+import { COLORS } from "../theme";
 
 const styles: StyleObject = {
   ...expandProperty("transition", "background-color 5000s ease-in-out 0s"),
   ...expandProperty("boxShadow", "inset 0 0 20px 20px #23232329"),
   "-webkit-background-clip": "text",
-  "-webkit-text-fill-color": PRIMITIVE_COLORS.gray50,
+  "-webkit-text-fill-color": COLORS.gray50,
 };
 
 export const resetAutoCompleteStyles = {

--- a/src/shared/theme/checkmarkCommonLabelStyles.ts
+++ b/src/shared/theme/checkmarkCommonLabelStyles.ts
@@ -1,19 +1,19 @@
 import { expandProperty } from "inline-style-expand-shorthand";
 import { StyleObject } from "styletron-standard";
-import { PRIMITIVE_COLORS } from "./colors";
+import { COLORS } from "./colors";
 
 export const getCheckmarkLabelStyles = (disabled: boolean): StyleObject => {
   const transition = expandProperty("transition", "color 0.15sease-in");
 
   if (disabled) {
     return {
-      color: PRIMITIVE_COLORS.gray500,
+      color: COLORS.gray500,
       ...transition,
     };
   }
 
   return {
-    color: PRIMITIVE_COLORS.gray50,
+    color: COLORS.gray50,
     ...transition,
   };
 };

--- a/src/shared/theme/colors.ts
+++ b/src/shared/theme/colors.ts
@@ -1,6 +1,6 @@
 import { DefaultTheme } from "./types";
 
-export const PRIMITIVE_COLORS = {
+export const COLORS = {
   gray50: "#F1F1F1",
   gray100: "#D6D6D6",
   gray200: "#BDBDBD",
@@ -86,22 +86,22 @@ export const PRIMITIVE_COLORS = {
 export const createColors = (): DefaultTheme => {
   return {
     primitives: {
-      ...PRIMITIVE_COLORS,
-      primaryA: PRIMITIVE_COLORS.gray200,
-      primaryB: PRIMITIVE_COLORS.gray900,
+      ...COLORS,
+      primaryA: COLORS.gray200,
+      primaryB: COLORS.gray900,
     },
     overrides: {
       colors: {
-        gray50: PRIMITIVE_COLORS.gray50,
-        gray100: PRIMITIVE_COLORS.gray100,
-        gray200: PRIMITIVE_COLORS.gray200,
-        gray300: PRIMITIVE_COLORS.gray300,
-        gray400: PRIMITIVE_COLORS.gray400,
-        gray500: PRIMITIVE_COLORS.gray500,
-        gray600: PRIMITIVE_COLORS.gray600,
-        gray700: PRIMITIVE_COLORS.gray700,
-        gray800: PRIMITIVE_COLORS.gray800,
-        gray900: PRIMITIVE_COLORS.gray900,
+        gray50: COLORS.gray50,
+        gray100: COLORS.gray100,
+        gray200: COLORS.gray200,
+        gray300: COLORS.gray300,
+        gray400: COLORS.gray400,
+        gray500: COLORS.gray500,
+        gray600: COLORS.gray600,
+        gray700: COLORS.gray700,
+        gray800: COLORS.gray800,
+        gray900: COLORS.gray900,
       },
     },
   };

--- a/src/shared/theme/colors.ts
+++ b/src/shared/theme/colors.ts
@@ -83,6 +83,12 @@ export const COLORS = {
   mono600: "#292929",
 } as const;
 
+/**
+ * @deprecated
+ * Use `COLORS` instead.
+ */
+export const PRIMITIVE_COLORS = { ...COLORS };
+
 export const createColors = (): DefaultTheme => {
   return {
     primitives: {

--- a/src/shared/theme/index.ts
+++ b/src/shared/theme/index.ts
@@ -1,5 +1,5 @@
 export { createTheme } from "./theme";
-export { PRIMITIVE_COLORS } from "./colors";
+export { COLORS } from "./colors";
 export { svgInlineDotsPattern } from "./pattern";
 export { SPACE } from "./space";
 

--- a/src/shared/theme/index.ts
+++ b/src/shared/theme/index.ts
@@ -1,5 +1,5 @@
 export { createTheme } from "./theme";
-export { COLORS } from "./colors";
+export { COLORS, PRIMITIVE_COLORS } from "./colors";
 export { svgInlineDotsPattern } from "./pattern";
 export { SPACE } from "./space";
 

--- a/src/shared/theme/textFieldCommonOverrides.ts
+++ b/src/shared/theme/textFieldCommonOverrides.ts
@@ -1,39 +1,39 @@
 import { StyleObject } from "styletron-standard";
 import { INPUT_KIND, SELECT_KIND, TEXTAREA_KIND } from "../../components";
-import { PRIMITIVE_COLORS } from "./colors";
+import { COLORS } from "./colors";
 import { expandProperty } from "inline-style-expand-shorthand";
 
 type TextFiledKindUnion = INPUT_KIND | TEXTAREA_KIND | SELECT_KIND;
 
 export const getColor = (isFocused: boolean, error: boolean, disabled: boolean): string => {
   if (isFocused) {
-    return PRIMITIVE_COLORS.gray50;
+    return COLORS.gray50;
   }
 
   if (error) {
-    return PRIMITIVE_COLORS.red400;
+    return COLORS.red400;
   }
 
   if (disabled) {
-    return PRIMITIVE_COLORS.gray400;
+    return COLORS.gray400;
   }
 
-  return PRIMITIVE_COLORS.gray50;
+  return COLORS.gray50;
 };
 
 export const getPlaceholderColor = (disabled: boolean): string => {
-  return disabled ? PRIMITIVE_COLORS.gray400 : PRIMITIVE_COLORS.gray200;
+  return disabled ? COLORS.gray400 : COLORS.gray200;
 };
 
 export const getBackgroundColor = (kind: TextFiledKindUnion): StyleObject => {
   if (kind === INPUT_KIND.secondary) {
     return {
-      backgroundColor: PRIMITIVE_COLORS.gray900,
+      backgroundColor: COLORS.gray900,
     };
   }
 
   return {
-    backgroundColor: PRIMITIVE_COLORS.gray800,
+    backgroundColor: COLORS.gray800,
   };
 };
 
@@ -53,8 +53,8 @@ export const getHoverStyles = (
     return {
       ...transition,
       ":hover": {
-        backgroundColor: PRIMITIVE_COLORS.gray800,
-        ...(!isFocused && !isError ? expandProperty("borderColor", PRIMITIVE_COLORS.gray800) : {}),
+        backgroundColor: COLORS.gray800,
+        ...(!isFocused && !isError ? expandProperty("borderColor", COLORS.gray800) : {}),
       },
     };
   }
@@ -62,8 +62,8 @@ export const getHoverStyles = (
   return {
     ...transition,
     ":hover": {
-      backgroundColor: PRIMITIVE_COLORS.gray700,
-      ...(!isFocused && !isError ? expandProperty("borderColor", PRIMITIVE_COLORS.gray700) : {}),
+      backgroundColor: COLORS.gray700,
+      ...(!isFocused && !isError ? expandProperty("borderColor", COLORS.gray700) : {}),
     },
   };
 };

--- a/src/shared/ui/colors-stories/ColorPlate.tsx
+++ b/src/shared/ui/colors-stories/ColorPlate.tsx
@@ -2,7 +2,7 @@ import { LabelMedium, LabelXSmall } from "baseui/typography";
 import { useStyletron } from "styletron-react";
 import { StyleObject } from "styletron-standard";
 import { CopyButton } from "../../../components";
-import { PRIMITIVE_COLORS } from "../../theme";
+import { COLORS } from "../../theme";
 
 type ColorPlateProps = {
   colorHex: string;
@@ -21,7 +21,7 @@ const containerStyles: StyleObject = {
 const ColorPlate: React.FC<ColorPlateProps> = ({ colorHex, colorName }) => {
   const [css] = useStyletron();
   const colorInteger = hexToInteger(colorHex);
-  const bgColor = colorInteger < 5000000 ? PRIMITIVE_COLORS.gray300 : "transparent";
+  const bgColor = colorInteger < 5000000 ? COLORS.gray300 : "transparent";
 
   return (
     <div className={css({ ...containerStyles, backgroundColor: bgColor })}>
@@ -29,7 +29,7 @@ const ColorPlate: React.FC<ColorPlateProps> = ({ colorHex, colorName }) => {
         {colorName}
         <CopyButton textToCopy={colorHex} />
       </LabelMedium>
-      <LabelXSmall color={PRIMITIVE_COLORS.gray500}>{colorHex}</LabelXSmall>
+      <LabelXSmall color={COLORS.gray500}>{colorHex}</LabelXSmall>
     </div>
   );
 };

--- a/src/shared/ui/colors-stories/Colors.stories.mdx
+++ b/src/shared/ui/colors-stories/Colors.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Source, Canvas, Story } from "@storybook/blocks";
 import StoriesLayout from "../stories-layout";
-import { PRIMITIVE_COLORS } from "../../theme";
+import { COLORS } from "../../theme";
 import ColorPlate from "./ColorPlate";
 
 <Meta title="Media/Colors" />
@@ -10,8 +10,8 @@ import ColorPlate from "./ColorPlate";
 export const Template = () => {
   return (
     <StoriesLayout isColumn>
-      {Object.keys(PRIMITIVE_COLORS).map((color) => (
-        <ColorPlate key={color} colorHex={PRIMITIVE_COLORS[color]} colorName={color} />
+      {Object.keys(COLORS).map((color) => (
+        <ColorPlate key={color} colorHex={COLORS[color]} colorName={color} />
       ))}
     </StoriesLayout>
   );
@@ -28,13 +28,13 @@ export const Template = () => {
   dark
   format={true}
   code={`
-    import { LabelMedium, PRIMITIVE_COLORS } from "@nilfoundation/ui-kit";
+    import { LabelMedium, COLORS } from "@nilfoundation/ui-kit";
 
     ...
     function MyComponent() {
       ...
       return (
-        <LabelMedium color={PRIMITIVE_COLORS.red300}>Label</LabelMedium>
+        <LabelMedium color={COLORS.red300}>Label</LabelMedium>
       )
     }
 

--- a/src/shared/ui/pattern-layout/styles.ts
+++ b/src/shared/ui/pattern-layout/styles.ts
@@ -1,4 +1,4 @@
-import { PRIMITIVE_COLORS } from "../..";
+import { COLORS } from "../..";
 import { StyleObject } from "styletron-react";
 import { PATTERN_KIND } from "./types";
 
@@ -6,7 +6,7 @@ export const getContainerStyles = (width: string, height: string, kind: PATTERN_
   position: "relative",
   width: width,
   height: height,
-  backgroundColor: kind === PATTERN_KIND.pattern800 ? PRIMITIVE_COLORS.gray800 : PRIMITIVE_COLORS.gray700,
+  backgroundColor: kind === PATTERN_KIND.pattern800 ? COLORS.gray800 : COLORS.gray700,
   boxSizing: "border-box",
 });
 
@@ -25,7 +25,7 @@ export const getRowWrapperStyles = (kind: PATTERN_KIND): StyleObject => ({
   display: "flex",
   boxSizing: "border-box",
   backgroundImage: `linear-gradient(to right, ${
-    kind === PATTERN_KIND.pattern800 ? PRIMITIVE_COLORS.gray700 : PRIMITIVE_COLORS.gray900
+    kind === PATTERN_KIND.pattern800 ? COLORS.gray700 : COLORS.gray900
   } 25%, transparent 25%)`,
   backgroundSize: "8px 4px",
   marginBottom: "2px",


### PR DESCRIPTION
Replacement of PRIMITIVE_COLORS variable with COLORS to make it shorter and more convenient to use. Name primitive colors makes no since we have no "non-primitive" colors.