### PR TITLE
Make codemirror/view and highlight peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@codemirror/state": "6.4.0",
+    "@codemirror/view": ">=6.4.0 < 7",
+    "@lezer/highlight": "1.2.0",
     "@uiw/codemirror-themes": ">=4.21.0 < 5",
     "@uiw/react-codemirror": ">=4.21.0 < 5",
     "baseui": ">=13.0.0 < 14",


### PR DESCRIPTION
This diff makes `codemirror/view` and `highlight` peer dependencies in order not included in the bundle. They were included in the package so it was x2 size of its normal size. They probably were added by mistake, we don't need them in the bundle.