### PR TITLE
Fix menu item isHighlighted prop styles

### DIFF
--- a/src/components/menu/Menu.stories.mdx
+++ b/src/components/menu/Menu.stories.mdx
@@ -3,7 +3,6 @@ import Menu from "./Menu";
 import { MENU_SIZE } from "./types";
 import { SearchIcon } from "../icons";
 import { COLORS } from "../../shared";
-import { BUTTON_KIND, Button } from "../button";
 
 <Meta title="Overlay/Menu" component={Menu} />
 
@@ -18,7 +17,7 @@ export const Template = ({ ...args }) => {
 export const ITEMS = [{ label: "Item One" }, { label: "Item Two" }, { label: "Item Three" }, { label: "Item Four" }];
 
 export const ITEMS_WITH_DIVIDER = [
-  { label: "Item One" },
+  { label: <div>Item One</div> },
   { divider: true },
   { label: "Item Two" },
   { label: "Item Three", disabled: true },
@@ -32,10 +31,10 @@ export const ITEMS_WITH_LINKS = [
   { divider: true },
   {
     label: "Item Three",
-    linkComponent: ({ children, href }) => (
-      <Button kind={BUTTON_KIND.secondary}>
-        <a href={href}>{children}</a>
-      </Button>
+    linkComponent: ({ children, href, className }) => (
+      <a href={href} className={className}>
+        {children}
+      </a>
     ),
     href: "/",
   },
@@ -131,5 +130,11 @@ To use, import the component `Menu` from `@nilfoundation/ui-kit`.
         <Menu size={MENU_SIZE.small} items={[...ITEMS, { label: "Item Fifth", endEnhancer: <SearchIcon />}]} />
         // With suffix text
         <Menu size={MENU_SIZE.small} items={[...ITEMS, { label: "Item Fifth", suffixText: "Text"}]} />
+        // With custom link component
+        <Menu items={[{
+          label: "Item One",
+          href: "/",
+          linkComponent: ({ children, href, className }) => <a href={href} className={className}>{children}</a>
+        }]} />
   `}
 />

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -1,4 +1,4 @@
 export { default as Menu } from "./Menu";
 
 export { MENU_SIZE } from "./types";
-export type { MenuProps } from "./types";
+export type { MenuProps, MenuItem, Items, GroupedItems, ItemDivider } from "./types";

--- a/src/components/menu/styles.ts
+++ b/src/components/menu/styles.ts
@@ -8,9 +8,9 @@ export const listStyles = {
   ...withoutBorderStyles,
   ...expandProperty("borderRadius", "8px"),
   ...expandProperty("padding", "8px"),
-  ...expandProperty("boxShadow", "none"),
+  boxShadow: "none",
   outline: "none !important",
-  backgroundColor: COLORS.gray900,
+  backgroundColor: COLORS.gray800,
 };
 
 export const headerBaseStyles: StyleObject = {
@@ -40,7 +40,6 @@ export const headerModifiedStyles = {
 
 const itemModifiedStyles = {
   [MENU_SIZE.small]: {
-    padding: "6px 12px",
     ...expandProperty("padding", "6px 12px"),
     height: "32px",
   },
@@ -54,45 +53,39 @@ const itemModifiedStyles = {
   },
 };
 
-const itemSelectedStyles: StyleObject = {
-  backgroundColor: COLORS.gray800,
-};
-
-const itemDisabledStyles = {
-  backgroundColor: "transparent",
-  color: COLORS.gray600,
-  cursor: "not-allowed",
-
-  ":hover": {
-    backgroundColor: "transparent",
-    color: COLORS.gray600,
+const linkComponentModifiedStyles = {
+  [MENU_SIZE.small]: {
+    ...expandProperty("margin", "-6px -12px"),
+    ...expandProperty("padding", "6px 12px"),
   },
-
-  ":hover > div": {
-    color: COLORS.gray600,
+  [MENU_SIZE.medium]: {
+    ...expandProperty("margin", "-6px -16px"),
+    ...expandProperty("padding", "0 16px"),
   },
-
-  ":hover > svg": {
-    fill: COLORS.gray600,
+  [MENU_SIZE.large]: {
+    ...expandProperty("margin", "-6px -16px"),
+    ...expandProperty("padding", "0 16px"),
   },
 };
 
-const itemHighlightedStyles: StyleObject = {
-  backgroundColor: COLORS.gray800,
-  color: COLORS.white,
+const ativeItemStyles: StyleObject = {
+  backgroundColor: COLORS.gray600,
+  color: COLORS.gray50,
+  fill: COLORS.gray50,
 };
 
-export const svgActiveStyles: StyleObject = {
-  fill: COLORS.white,
+export const svgStyles: StyleObject = {
+  fill: "inherit",
 };
 
 export const getItemContainerStyles = (
   size: MENU_SIZE,
   disabled: boolean,
   isHighlighted: boolean,
-  ariaSelected: boolean
+  selected: boolean,
+  isActive: boolean
 ): StyleObject => {
-  return {
+  const constantStyles = {
     display: "flex",
     alignItems: "center",
     width: "100%",
@@ -100,47 +93,48 @@ export const getItemContainerStyles = (
     cursor: "pointer",
     gap: "8px",
     color: COLORS.gray200,
+    backgroundColor: "transparent",
     fontWeight: 500,
     ...expandProperty("borderRadius", "4px"),
-    ...expandProperty("transition", "color 0.15s"),
-
-    ":hover": {
-      backgroundColor: COLORS.gray800,
-      color: COLORS.white,
-    },
-
-    ":hover > div": {
-      color: COLORS.white,
-    },
-
-    ":hover > svg": {
-      fill: COLORS.white,
-    },
-
+    ...expandProperty("transition", "background-color 0.15s, color 0.15s, fill 0.15s"),
     ...itemModifiedStyles[size],
-    ...(ariaSelected ? itemSelectedStyles : {}),
-    ...(isHighlighted ? itemHighlightedStyles : {}),
-    ...(disabled ? itemDisabledStyles : {}),
+  } as const;
+
+  if (disabled) {
+    return {
+      ...constantStyles,
+      backgroundColor: "transparent",
+      color: COLORS.gray600,
+      cursor: "not-allowed",
+    };
+  }
+
+  if (selected || isHighlighted || isActive) {
+    return {
+      ...constantStyles,
+      ...ativeItemStyles,
+    };
+  }
+
+  return {
+    ...constantStyles,
+    ":hover": {
+      backgroundColor: COLORS.gray700,
+      color: COLORS.gray50,
+      fill: COLORS.gray50,
+    },
   };
 };
 
-export const LinkComponentStyles = {
+export const getLinkComponentStyles = (size: MENU_SIZE): StyleObject => ({
   display: "flex",
   alignItems: "center",
   width: "100%",
   height: "100%",
   gap: "8px",
-};
-
-export const getItemParagraphColor = (isActive: boolean, isDisabled: boolean) => {
-  if (isDisabled) {
-    return COLORS.gray600;
-  }
-  if (isActive) {
-    return COLORS.gray50;
-  }
-  return COLORS.gray200;
-};
+  backgroundColor: "transparent",
+  ...linkComponentModifiedStyles[size],
+});
 
 export const itemTypographyStyles = {
   textDecoration: "none",

--- a/src/components/menu/types.ts
+++ b/src/components/menu/types.ts
@@ -1,6 +1,7 @@
-import { Item, RenderItemProps, StatefulMenuProps } from "baseui/menu";
+import { StatefulMenuProps } from "baseui/menu";
 import { ParagraphSmall } from "baseui/typography";
 import { ComponentProps, ReactElement, ReactNode } from "react";
+import { LinkComponentRenderFunction } from "../../shared";
 
 export enum MENU_SIZE {
   "small" = "small",
@@ -8,26 +9,36 @@ export enum MENU_SIZE {
   "large" = "large",
 }
 
-export type MenuProps = StatefulMenuProps & {
-  size?: MENU_SIZE;
-};
-
 export type MenuItemTypographyProps = ComponentProps<typeof ParagraphSmall>;
 
-export type TExpandedItem = Item & {
+export type MenuItem = {
+  /** Highlights item nad adds a checkbox if true */
   selected?: boolean;
   suffixText?: string;
-  startEnhancer?: ReactNode;
-  endEnhancer?: ReactNode;
+  startEnhancer?: ReactElement;
+  endEnhancer?: ReactElement;
+  /** Adds checkmark */
   isActive?: boolean;
-  linkComponent?: ReactElement;
+  linkComponent?: LinkComponentRenderFunction;
+  href?: string;
+  /** Highlights item as it was selected */
+  isHighlighted?: boolean;
+  label: ReactNode;
+  disabled?: boolean;
 };
 
-export type MenuItemProps = RenderItemProps & {
-  item: TExpandedItem;
-  size: MENU_SIZE;
-  disabled?: boolean;
-  ariaSelected?: boolean;
-  isHighlighted?: boolean;
-  children?: ReactNode;
+export type ItemDivider = {
+  divider: true;
+};
+
+export type Items = Array<MenuItem | ItemDivider>;
+
+export type GroupedItems = {
+  __ungrouped: Items;
+  [x: string]: Items;
+};
+
+export type MenuProps = Omit<StatefulMenuProps, "items"> & {
+  size?: MENU_SIZE;
+  items: Items | GroupedItems;
 };

--- a/src/components/menu/ui/MenuItem.tsx
+++ b/src/components/menu/ui/MenuItem.tsx
@@ -1,19 +1,19 @@
 import { cloneElement, forwardRef } from "react";
-import { MENU_SIZE, MenuItemProps, MenuItemTypographyProps } from "../types";
+import { MENU_SIZE, MenuItemTypographyProps } from "../types";
 import { ParagraphSmall, ParagraphMedium, ParagraphLarge } from "baseui/typography";
 import { useStyletron, styled } from "baseui";
 import { Checkbox } from "../../checkbox";
 import {
   getItemContainerStyles,
-  getItemParagraphColor,
-  LinkComponentStyles,
+  getLinkComponentStyles,
   ItemEndWrapperStyles,
   itemTypographyStyles,
-  svgActiveStyles,
+  svgStyles,
 } from "../styles";
 import { CheckmarkIcon } from "../../icons";
 import { COLORS } from "../../../shared";
 import { getCustomLinkComponent } from "../../../shared/ui/getCustomLinkComponent";
+import { MenuItemComponentProps } from "./types";
 
 const paragraphComponent = {
   [MENU_SIZE.small]: (props: MenuItemTypographyProps) => <ParagraphSmall as="div" {...props} />,
@@ -27,35 +27,37 @@ const iconSizeMap = {
   [MENU_SIZE.large]: 32,
 };
 
-const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
-  ({ size, item, onClick, disabled, ariaSelected, isHighlighted, onMouseEnter, id }, ref) => {
+const MenuItem = forwardRef<HTMLLIElement, MenuItemComponentProps>(
+  ({ size, item, onClick, disabled, onMouseEnter, id }, ref) => {
     const [css] = useStyletron();
 
-    const isAreaSelected = ariaSelected && !disabled;
-    const paragraphColor = getItemParagraphColor(isAreaSelected || !!isHighlighted, !!disabled);
-    const Item = styled("li", getItemContainerStyles(size, !!disabled, !!isHighlighted, !!ariaSelected));
+    const isSelected = item.selected && !disabled;
+    const Item = styled(
+      "li",
+      getItemContainerStyles(size, !!disabled, !!item.isHighlighted, !!isSelected, !!item.isActive)
+    );
     const EndWrapper = styled("span", ItemEndWrapperStyles);
     const TypographyComponent = paragraphComponent[size];
     const LinkComponent = getCustomLinkComponent(item.linkComponent, item.href);
 
     return (
       <Item ref={ref} onMouseEnter={onMouseEnter} id={id ?? undefined} onClick={onClick}>
-        <LinkComponent className={css(LinkComponentStyles)}>
+        <LinkComponent className={css(getLinkComponentStyles(size))}>
           {item?.selected != null && <Checkbox checked={item.selected} />}
           {item?.startEnhancer &&
             cloneElement(item.startEnhancer, {
               size: iconSizeMap[size],
-              className: css(isAreaSelected ? svgActiveStyles : {}),
+              className: css(svgStyles),
             })}
-          <TypographyComponent className={css(itemTypographyStyles)} color={paragraphColor}>
+          <TypographyComponent className={css(itemTypographyStyles)} color="inherit">
             {item.label}
           </TypographyComponent>
           <EndWrapper>
-            {item?.suffixText && <TypographyComponent color={paragraphColor}>{item.suffixText}</TypographyComponent>}
+            {item?.suffixText && <TypographyComponent color="inherit">{item.suffixText}</TypographyComponent>}
             {item?.endEnhancer &&
               cloneElement(item.endEnhancer, {
                 size: iconSizeMap[size],
-                className: css(isAreaSelected ? svgActiveStyles : {}),
+                className: css(svgStyles),
               })}
           </EndWrapper>
           {item?.isActive && <CheckmarkIcon size={iconSizeMap[size]} color={COLORS.gray300} />}

--- a/src/components/menu/ui/types.ts
+++ b/src/components/menu/ui/types.ts
@@ -1,0 +1,13 @@
+import { ReactNode } from "react";
+import { MENU_SIZE, MenuItem } from "../types";
+
+export type MenuItemComponentProps = {
+  item: MenuItem;
+  size: MENU_SIZE;
+  disabled?: boolean;
+  ariaSelected?: boolean;
+  children?: ReactNode;
+  onClick?: () => void;
+  onMouseEnter?: () => void;
+  id?: string;
+};

--- a/src/components/navigation-bar/types.ts
+++ b/src/components/navigation-bar/types.ts
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 export type NavigationItem<T = unknown> = T & {
   id: string;
   label: ReactNode;
-  isSelected?: boolean;
+  selected?: boolean;
   disabled?: boolean;
   children?: Array<NavigationItem<T>>;
   href?: string;

--- a/src/components/navigation-bar/ui/menu-navigation/NavItem.tsx
+++ b/src/components/navigation-bar/ui/menu-navigation/NavItem.tsx
@@ -24,7 +24,7 @@ const NavItem: FC<NavItemProps> = ({ item, onItemClick, itemAs }) => {
   const [isOpen, setOpen] = useState(false);
 
   const { label } = item;
-  const isSelected = !!item?.isSelected;
+  const isSelected = !!item?.selected;
   const disabled = !!item?.disabled;
   const children = item?.children ?? [];
 

--- a/src/components/select/overrides.tsx
+++ b/src/components/select/overrides.tsx
@@ -78,7 +78,11 @@ export const getSelectOverrides = (
     Dropdown: {
       style: () => ({
         ...expandProperty("borderRadius", "8px"),
+        ...expandProperty("padding", "8px"),
         backgroundColor: COLORS.gray800,
+        display: "flex",
+        flexDirection: "column",
+        gap: "2px",
       }),
     },
     Popover: {

--- a/src/shared/ui/getCustomLinkComponent.tsx
+++ b/src/shared/ui/getCustomLinkComponent.tsx
@@ -13,6 +13,7 @@ export type LinkComponentRenderFunction = (props: LinkComponentProps) => ReactEl
 const ResetLink = styled("a", {
   color: "inherit",
   cursor: "unset",
+  backgroundColor: "transparent",
   textDecoration: "none",
   ":hover": {
     textDecoration: "none",


### PR DESCRIPTION
This diff mitigates several issues:
- `isHighlighted` prop didn't work - and we were unable to show selected url for example
- Add strong typings to menu items, which enables autocomplete and eases understanding of component usage
- Fix some menu items styling

closes #288 