### PR TITLE
Update @codemirror/state to v6.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "vite-plugin-externalize-deps": "^0.6.0"
       },
       "peerDependencies": {
-        "@codemirror/state": "6.4.0",
+        "@codemirror/state": "6.5.0",
         "@codemirror/view": ">=6.4.0 < 7",
         "@lezer/highlight": "1.2.0",
         "@uiw/codemirror-themes": ">=4.21.0 < 5",
@@ -2224,10 +2224,13 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
-      "integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
-      "peer": true
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+      "peer": true,
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
     },
     "node_modules/@codemirror/theme-one-dark": {
       "version": "6.1.2",
@@ -3759,6 +3762,12 @@
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "peer": true
     },
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@codemirror/state": "6.4.0",
+    "@codemirror/state": "6.5.0",
     "@codemirror/view": ">=6.4.0 < 7",
     "@lezer/highlight": "1.2.0",
     "@uiw/codemirror-themes": ">=4.21.0 < 5",


### PR DESCRIPTION
This diff updated `@codemirror/state` dependency to `v6.5.0`.
We have some packages in the main nil repo which use `v6.5.0` already and there are duplicated `@codemirror/state` npm packages because of that reason. Instead of allying lots of fixes to nil repo it is better to upgrade version here, moreover it does not break anything.