### PR TITLE
fix: fix esm filenames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "copy-to-clipboard": "^3.3.3",
         "inline-style-expand-shorthand": "^1.6.0",
-        "lightweight-charts-react-components": "^0.3.3",
+        "lightweight-charts-react-components": "^0.4.0",
         "styletron-standard": "^3.1.0",
         "ts-deepmerge": "^7.0.2",
         "ts-essentials": "^10.0.1"
@@ -15509,9 +15509,9 @@
       }
     },
     "node_modules/lightweight-charts-react-components": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lightweight-charts-react-components/-/lightweight-charts-react-components-0.3.3.tgz",
-      "integrity": "sha512-gw/4QFqyoSQG7swF7vVNiZ6c/FE/TvwDEPxadjHAJOrTA+FPxo7pJXUzu3A+gUTThJzPcMMeRKZch2Gj83oafw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lightweight-charts-react-components/-/lightweight-charts-react-components-0.4.1.tgz",
+      "integrity": "sha512-7e5m+RNptAyvtOiktlsg/7Fd42f9qbNfRhOroyQBAihH0AdMu/1RySqv5K9A1veL0nWvqjluhcgtK3nwH/Wl+A==",
       "peerDependencies": {
         "lightweight-charts": ">=5 < 6",
         "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,21 @@
     "ui-kit",
     "react"
   ],
-  "main": "dist/ui-kit.cjs",
-  "module": "dist/ui-kit.js",
+  "main": "dist/ui-kit.mjs",
+  "module": "dist/ui-kit.mjs",
   "unpkg": "dist/ui-kit.iife.js",
   "types": "dist/ui-kit.d.ts",
   "files": [
     "dist"
   ],
   "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/ui-kit.d.ts",
+      "import": "./dist/ui-kit.mjs"
+    }
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -102,7 +109,7 @@
   "dependencies": {
     "copy-to-clipboard": "^3.3.3",
     "inline-style-expand-shorthand": "^1.6.0",
-    "lightweight-charts-react-components": "^0.3.3",
+    "lightweight-charts-react-components": "^0.4.0",
     "styletron-standard": "^3.1.0",
     "ts-deepmerge": "^7.0.2",
     "ts-essentials": "^10.0.1"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,8 +52,14 @@ export default defineConfig(({mode}) => {
       sourcemap: true,
       lib: {
         entry: resolve(__dirname, 'src/index.ts'),
-        formats: isStandalone ? ['iife'] : ['es', 'cjs'],
+        formats: isStandalone ? ['iife'] : ['es'],
         name: 'NilFoundationUIKit',
+        fileName: () => {
+          if (isStandalone) {
+            return 'ui-kit.iife.js';
+          }
+          return `ui-kit.mjs`;
+        },
       },
       rollupOptions: {
         output: {


### PR DESCRIPTION
This diff fixes esm filenames. Since ui-kit is esm-only we need `.mjs` extension. If it is just a `.js` some bundlers may still treat them as commonjs, which causes errors.